### PR TITLE
Fixed control plane installation on VM with Ubuntu (#39)

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -678,23 +678,4 @@ Function New-MasterNode {
     Set-UpMasterNode @masterNodeParams
 }
 
-
-Function Set-UpComputerWithSpecificOsBeforeProvisioning {
-    param (
-        [string] $UserName,
-        [string] $UserPwd,
-        [string] $IpAddress
-    )
-    # empty by intention
-}
-
-Function Set-UpComputerWithSpecificOsAfterProvisioning {
-    param (
-        [string]$UserName,
-        [string]$UserPwd,
-        [string]$IpAddress
-    )
-    # empty by intention
-}
-
 Export-ModuleMember -Function Install-Tools, Add-SupportForWSL, Set-UpMasterNode, New-KubernetesNode, New-MasterNode

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/ubuntu/ExistingUbuntuComputerAsMasterNodeInstaller.ps1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/ubuntu/ExistingUbuntuComputerAsMasterNodeInstaller.ps1
@@ -8,7 +8,6 @@ param (
     [ValidateScript({ !([string]::IsNullOrWhiteSpace($_))})]
     [string]$UserName = $(throw "Argument missing: UserName"),
     [string]$UserPwd = $(throw "Argument missing: UserPwd"),
-    [ValidateScript({ Get-IsValidIPv4Address($_) })]
     [string]$IpAddress = $(throw "Argument missing: IpAddress"),
     [string] $Proxy = ''
 )
@@ -21,7 +20,7 @@ $validationModule = "$global:KubernetesPath\lib\modules\k2s\k2s.infra.module\val
 $baseImageModule = "$global:KubernetesPath\smallsetup\baseimage\baseimage.module.psm1"
 $linuxNodeModule = "$global:KubernetesPath\smallsetup\linuxnode\linuxnode.module.psm1"
 $linuxNodeUbuntuModule = "$PSScriptRoot\ubuntu.module.psm1"
-Import-Module $validationModule,$baseImageModule,$linuxNodeModule,$linuxNodeUbuntuModule -Force
+Import-Module $validationModule,$baseImageModule,$linuxNodeModule,$linuxNodeUbuntuModule
 
 $remoteUser = "$UserName@$IpAddress"
 $remoteUserName = "$UserName"

--- a/smallsetup/InstallK8s.ps1
+++ b/smallsetup/InstallK8s.ps1
@@ -282,7 +282,7 @@ $reuseExistingLinuxComputer = !([string]::IsNullOrWhiteSpace($LinuxVMIP))
 Set-ConfigValue -Path $global:SetupJsonFile -Key $global:ConfigKey_ReuseExistingLinuxComputerForMasterNode -Value $reuseExistingLinuxComputer
 if ($reuseExistingLinuxComputer) {
     Write-Log "Configuring computer with IP '$LinuxVMIP' to act as Master Node"
-    &"$global:KubernetesPath\smallsetup\linuxnode\ubuntu\ExistingUbuntuComputerAsMasterNodeInstaller.ps1" -ComputerIP $LinuxVMIP -UserName $LinuxVMUsername -UserPwd $LinuxVMUserPwd -Proxy $Proxy
+    &"$global:KubernetesPath\smallsetup\linuxnode\ubuntu\ExistingUbuntuComputerAsMasterNodeInstaller.ps1" -IpAddress $LinuxVMIP -UserName $LinuxVMUsername -UserPwd $LinuxVMUserPwd -Proxy $Proxy
     Write-Log "Finished configuring computer with IP '$LinuxVMIP' to act as Master Node"
 
     Wait-ForSSHConnectionToLinuxVMViaSshKey

--- a/smallsetup/linuxnode/linuxnode.module.psm1
+++ b/smallsetup/linuxnode/linuxnode.module.psm1
@@ -718,23 +718,4 @@ Function New-MasterNode {
     Set-UpMasterNode @masterNodeParams
 }
 
-
-Function Set-UpComputerWithSpecificOsBeforeProvisioning {
-    param (
-        [string] $UserName,
-        [string] $UserPwd,
-        [string] $IpAddress
-    )
-    # empty by intention
-}
-
-Function Set-UpComputerWithSpecificOsAfterProvisioning {
-    param (
-        [string]$UserName,
-        [string]$UserPwd,
-        [string]$IpAddress
-    )
-    # empty by intention
-}
-
 Export-ModuleMember -Function Install-Tools, Add-SupportForWSL, Set-UpMasterNode, New-KubernetesNode, New-MasterNode

--- a/smallsetup/linuxnode/linuxnode.module.unit.tests.ps1
+++ b/smallsetup/linuxnode/linuxnode.module.unit.tests.ps1
@@ -1538,46 +1538,6 @@ Describe 'New-MasterNode' -Tag 'unit', 'linuxnode' {
     }
 }
 
-Describe 'Set-UpComputerWithSpecificOsBeforeProvisioning' -Tag 'unit', 'linuxnode' {
-    It "contains expected parameters" {
-        InModuleScope $linuxNodeModuleName {
-            # arrange
-            $expectedUserName = 'myUserName'
-            $expectedUserPwd = 'myUserPwd'
-            $expectedIpAddress = 'myIpAddress'
-
-            Mock Set-UpComputerWithSpecificOsBeforeProvisioning { $global:actualUserName = $UserName; $global:actualUserPwd = $UserPwd; $global:actualIpAddress = $IpAddress }
-
-            # act
-            Set-UpComputerWithSpecificOsBeforeProvisioning -UserName $expectedUserName -UserPwd $expectedUserPwd -IpAddress $expectedIpAddress
-
-            # assert
-            $global:actualUserName | Should -Be $expectedUserName
-            $global:actualUserPwd | Should -Be $expectedUserPwd
-            $global:actualIpAddress | Should -Be $expectedIpAddress
-        }
-    }
-}
-
-Describe 'Set-UpComputerWithSpecificOsAfterProvisioning' -Tag 'unit', 'linuxnode' {
-    It 'contains expected parameters' {
-        InModuleScope $linuxNodeModuleName {
-            # arrange
-            $expectedUserName = 'myUserName'
-            $expectedUserPwd = 'myUserPwd'
-            $expectedIpAddress = 'myIpAddress'
-            Mock Set-UpComputerWithSpecificOsAfterProvisioning { $global:actualUserName = $UserName; $global:actualUserPwd = $UserPwd; $global:actualIpAddress = $IpAddress; $global:actualProxy = $Proxy }
-
-            # act
-            Set-UpComputerWithSpecificOsAfterProvisioning -UserName $expectedUserName -UserPwd $expectedUserPwd -IpAddress $expectedIpAddress
-
-            # assert
-            $global:actualUserName | Should -Be $expectedUserName
-            $global:actualUserPwd | Should -Be $expectedUserPwd
-            $global:actualIpAddress | Should -Be $expectedIpAddress
-        }
-    }
-}
 
 
 

--- a/smallsetup/linuxnode/ubuntu/ExistingUbuntuComputerAsMasterNodeInstaller.ps1
+++ b/smallsetup/linuxnode/ubuntu/ExistingUbuntuComputerAsMasterNodeInstaller.ps1
@@ -8,7 +8,6 @@ param (
     [ValidateScript({ !([string]::IsNullOrWhiteSpace($_))})]
     [string]$UserName = $(throw "Argument missing: UserName"),
     [string]$UserPwd = $(throw "Argument missing: UserPwd"),
-    [ValidateScript({ Get-IsValidIPv4Address($_) })]
     [string]$IpAddress = $(throw "Argument missing: IpAddress"),
     [string] $Proxy = ''
 )
@@ -21,7 +20,7 @@ $validationModule = "$global:KubernetesPath\lib\modules\k2s\k2s.infra.module\val
 $baseImageModule = "$global:KubernetesPath\smallsetup\baseimage\baseimage.module.psm1"
 $linuxNodeModule = "$global:KubernetesPath\smallsetup\linuxnode\linuxnode.module.psm1"
 $linuxNodeUbuntuModule = "$PSScriptRoot\linuxnode.ubuntu.module.psm1"
-Import-Module $validationModule,$baseImageModule,$linuxNodeModule,$linuxNodeUbuntuModule -Force
+Import-Module $validationModule,$baseImageModule,$linuxNodeModule,$linuxNodeUbuntuModule
 
 $remoteUser = "$UserName@$IpAddress"
 $remoteUserName = "$UserName"

--- a/smallsetup/linuxnode/ubuntu/ExistingUbuntuComputerAsMasterNodeInstaller.unit.tests.ps1
+++ b/smallsetup/linuxnode/ubuntu/ExistingUbuntuComputerAsMasterNodeInstaller.unit.tests.ps1
@@ -69,15 +69,6 @@ Describe 'ExistingUbuntuComputerAsMasterNodeInstaller.ps1' -Tag 'unit', 'linuxno
             # act + assert
             { Invoke-Expression -Command "$scriptFile @DefaultParameterValues" } | Get-ExceptionMessage | Should -BeLike '*UserName*'
         }
-        It 'IpAddress' {
-            # arrange
-            Mock Get-IsValidIPv4Address { $true }
-            Mock Get-IsValidIPv4Address { $false } -ParameterFilter { $Value -eq $DefaultParameterValues.IpAddress }
-
-            # act + assert
-            { Invoke-Expression -Command "$scriptFile @DefaultParameterValues" } | Get-ExceptionMessage | Should -BeLike '*IpAddress*'
-            Should -Invoke -CommandName Get-IsValidIPv4Address -Times 1 -ParameterFilter { $Value -eq $DefaultParameterValues.IpAddress }
-        }
     }
     Context 'execution' {
         It "performs set-up using proxy '<proxyToUse>'" -ForEach @(


### PR DESCRIPTION
Fixes the installation of the control plane in a running VM with Ubuntu.

### Motivation

The installation was broken due to a mismatching parameter name and the usage of a not superseded method.

### Verification

1. Created a VM with Ubuntu Desktop 22.04
2. Created a Virtual Switch to connect the Windows Host with the VM
3. Installed the ssh server on the VM
4. Called the script ".\smallsetup\InstallK8s.ps1 -ShowLogs -LinuxVMIP '_the IP_' -LinuxVMUsername '_the user name_' -LinuxVMUserPwd '_the user password_'"

