### PR TITLE
Windows 11 changes breaks the k2s install

### DIFF
--- a/addons/Export.ps1
+++ b/addons/Export.ps1
@@ -143,12 +143,12 @@ try {
                     # load global settings
                     &$env:SystemDrive\k\smallsetup\common\GlobalVariables.ps1
 
-                    &$global:NerdctlExe -n 'k8s.io' pull $using:image --platform windows/amd64 2>&1 | Out-Null
+                    &$global:NerdctlExe -n 'k8s.io' pull $using:image --all-platforms 2>&1 | Out-Null
                     crictl pull $using:image
                 }
             }
             else {
-                &$global:NerdctlExe -n 'k8s.io' pull $image --platform windows/amd64 2>&1 | Out-Null
+                &$global:NerdctlExe -n 'k8s.io' pull $image --all-platforms 2>&1 | Out-Null
                 &$global:BinPath\crictl pull $image
             }
         }

--- a/lib/modules/k2s/k2s.node.module/windowsnode/downloader/downloader.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/windowsnode/downloader/downloader.module.psm1
@@ -100,7 +100,7 @@ function Invoke-DownloadWindowsImages($downloadsBaseDirectory, $Proxy) {
 
         # Now really pull image and ignore errors from ctr
         $ErrorActionPreference = 'Continue'
-        &$nerdctlExe -n="k8s.io" pull $sandboxImageName 2>&1 | Out-Null
+        &$nerdctlExe -n="k8s.io" pull $sandboxImageName --all-platforms 2>&1 | Out-Null
         $images = &$ctrExe -n="k8s.io" image ls 2>&1 | Out-String
 
         if ($images.Contains($sandboxImageName)) {

--- a/smallsetup/windowsnode/downloader/DownloadWindowsImages.ps1
+++ b/smallsetup/windowsnode/downloader/DownloadWindowsImages.ps1
@@ -76,7 +76,7 @@ function DownloadWindowsImages($baseDirectory) {
 
         # Now really pull image and ignore errors from ctr
         $ErrorActionPreference = 'Continue'
-        &$global:NerdctlExe -n="k8s.io" pull $sandboxImageName 2>&1 | Out-Null
+        &$global:NerdctlExe -n="k8s.io" pull $sandboxImageName --all-platforms 2>&1 | Out-Null
         $images = &$global:CtrExe -n="k8s.io" image ls | Out-String
 
         if ($images.Contains($sandboxImageName)) {


### PR DESCRIPTION
<!-- Does this PR fix an issue -->

Fixes issue #71 

### Motivation

Nerdctl now pulls all layers for windows images

### Modifications

Changed option to pull all layers

### Verification

Tested with CI workflow on windows 11
