### PR TITLE
Bump setup-go to v5 to fix slow cache copy

### DIFF
--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{env.GOVERSION}}
         cache-dependency-path: "**/*.sum"


### PR DESCRIPTION
Bump setup-go to v5 to fix slow cache copy