### PR TITLE
Fix: corrected documented path to bgo.cmd

### DIFF
--- a/pkg/k2s/README.md
+++ b/pkg/k2s/README.md
@@ -7,4 +7,4 @@ SPDX-License-Identifier: MIT
 # CLI for k2s setup
 
 ### Build command
-..\bin\bgo.cmd
+..\..\bin\bgo.cmd


### PR DESCRIPTION
Adapted path to bgo.cmd in the k2s readme file (\<installation folder\>\pkg\k2s\README.md)