### PR TITLE
Added proxy argument to kubectl download call (#119)

### DIFF
--- a/smallsetup/multivm/Install_MultiVMK8sSetup.ps1
+++ b/smallsetup/multivm/Install_MultiVMK8sSetup.ps1
@@ -350,7 +350,7 @@ function Install-KubectlOnHost() {
 
     # TODO: clone from SetupNode.ps1
     if (!(Test-Path "&$global:KubectlExe") -or ($previousKubernetesVersion -ne $global:KubernetesVersion)) {
-        DownloadFile "&$global:KubectlExe" https://dl.k8s.io/release/$global:KubernetesVersion/bin/windows/amd64/kubectl.exe $true
+        DownloadFile "&$global:KubectlExe" https://dl.k8s.io/release/$global:KubernetesVersion/bin/windows/amd64/kubectl.exe $true $Proxy
     }
 }
 


### PR DESCRIPTION
#119 
In the call to download the tool kubectl.exe the proxy argument was missing.