### PR TITLE
Removed not needed '&' in download target argument (#119)

### DIFF
--- a/smallsetup/multivm/Install_MultiVMK8sSetup.ps1
+++ b/smallsetup/multivm/Install_MultiVMK8sSetup.ps1
@@ -350,7 +350,7 @@ function Install-KubectlOnHost() {
 
     # TODO: clone from SetupNode.ps1
     if (!(Test-Path "&$global:KubectlExe") -or ($previousKubernetesVersion -ne $global:KubernetesVersion)) {
-        DownloadFile "&$global:KubectlExe" https://dl.k8s.io/release/$global:KubernetesVersion/bin/windows/amd64/kubectl.exe $true
+        DownloadFile "&$global:KubectlExe" https://dl.k8s.io/release/$global:KubernetesVersion/bin/windows/amd64/kubectl.exe $true $Proxy
     }
 }
 

--- a/smallsetup/multivm/Install_MultiVMK8sSetup.ps1
+++ b/smallsetup/multivm/Install_MultiVMK8sSetup.ps1
@@ -349,8 +349,8 @@ function Install-KubectlOnHost() {
     }
 
     # TODO: clone from SetupNode.ps1
-    if (!(Test-Path "&$global:KubectlExe") -or ($previousKubernetesVersion -ne $global:KubernetesVersion)) {
-        DownloadFile "&$global:KubectlExe" https://dl.k8s.io/release/$global:KubernetesVersion/bin/windows/amd64/kubectl.exe $true $Proxy
+    if (!(Test-Path "$global:KubectlExe") -or ($previousKubernetesVersion -ne $global:KubernetesVersion)) {
+        DownloadFile "$global:KubectlExe" https://dl.k8s.io/release/$global:KubernetesVersion/bin/windows/amd64/kubectl.exe $true $Proxy
     }
 }
 


### PR DESCRIPTION
#119 
The download target argument for kubectl.exe contained a not needed '&' sign at the beginning.