### PR TITLE
Changed flag name for autoconfirmation of use of alternative ports in addon 'exthttpaccess'

### DIFF
--- a/addons/exthttpaccess/Enable.ps1
+++ b/addons/exthttpaccess/Enable.ps1
@@ -26,7 +26,7 @@ Param(
   [parameter(Mandatory = $false, HelpMessage = 'JSON config object to override preceeding parameters')]
   [pscustomobject] $Config,
   [parameter(Mandatory = $false, HelpMessage = 'Use the alternative ports 8080/8443 instead of 80/443 in case they are not free without user confirmation.')]
-  [switch]$ForceUseAlternativePortsIfNeeded = $false,
+  [switch]$AutoconfirmUseAlternativePortsIfNeeded = $false,
   [parameter(Mandatory = $false, HelpMessage = 'If set to true, will encode and send result as structured data to the CLI.')]
   [switch] $EncodeStructuredOutput,
   [parameter(Mandatory = $false, HelpMessage = 'Message type of the encoded structure; applies only if EncodeStructuredOutput was set to $true')]
@@ -95,7 +95,7 @@ $isPort443Used = DetermineIfPortIsUsed -Port $httpsPortNumberToUse
 
 if ($isPort80Used -or $isPort443Used) {
 
-  if ($ForceUseAlternativePortsIfNeeded) {
+  if ($AutoconfirmUseAlternativePortsIfNeeded) {
     $useAlternativePorts = 0
   } else {
     $title = 'The ports 80 and/or 443 are already in use.'

--- a/addons/exthttpaccess/addon.manifest.yaml
+++ b/addons/exthttpaccess/addon.manifest.yaml
@@ -26,10 +26,10 @@ spec:
             shorthand: p
             default: ""
             description: HTTP Proxy
-          - name: force-use-alternative-ports-if-needed
-            shorthand: f
+          - name: autoconfirm-alt-ports
+            shorthand: a
             default: false
-            description: Use the alternative ports 8080/8443 instead of 80/443 in case they are not free without user confirmation
+            description: Automatically switch to alternative ports 8080/8443 if 80/443 are busy without user confirmation
         examples:
           - cmd: k2s addons enable exthttpaccess
             comment: Enable exthttpaccess in k2s
@@ -40,8 +40,8 @@ spec:
         parameterMappings:
           - cliFlagName: proxy
             scriptParameterName: Proxy
-          - cliFlagName: force-use-alternative-ports-if-needed
-            scriptParameterName: ForceUseAlternativePortsIfNeeded
+          - cliFlagName: autoconfirm-alt-ports
+            scriptParameterName: AutoconfirmUseAlternativePortsIfNeeded
     disable:
       cli:
         examples:

--- a/test/e2e/addons/exthttpaccess/exthttpsaccess_test.go
+++ b/test/e2e/addons/exthttpaccess/exthttpsaccess_test.go
@@ -62,7 +62,7 @@ var _ = Describe("'exthttpaccess' addon", Ordered, func() {
 			var output string
 
 			BeforeAll(func(ctx context.Context) {
-				args := []string{"addons", "enable", "exthttpaccess", "-f"}
+				args := []string{"addons", "enable", "exthttpaccess", "-a"}
 				if suite.Proxy() != "" {
 					args = append(args, "-p", suite.Proxy())
 				}


### PR DESCRIPTION
#88 
In the exthttpaccess addon the flag `--force-use-alternative-ports-if-needed` (shortcut '`-f`') was changed to `--autoconfirm-alt-ports` (shortcut '`-a`')