### PR TITLE
Fix for test suite 'New-KubernetesNode'

### DIFF
--- a/smallsetup/linuxnode/linuxnode.module.unit.tests.ps1
+++ b/smallsetup/linuxnode/linuxnode.module.unit.tests.ps1
@@ -1198,6 +1198,8 @@ Describe 'New-KubernetesNode' -Tag 'unit', 'linuxnode' {
                 $expectedIpAddress = 'myIpAddress'
                 $expectedK8sVersion = 'myK8sVersion'
                 $expectedCrioVersion = 'myCrioVersion'
+                function Set-UpComputerWithSpecificOsBeforeProvisioning {}
+                function Set-UpComputerWithSpecificOsAfterProvisioning {}
                 $global:actualMethodsCallOrder = @()
                 Mock Get-IsValidIPv4Address { $true }
                 Mock Write-Log { }


### PR DESCRIPTION
**Root cause:**
In production the module `'linuxnode.module.psm1'` works together with one of the following specialization modules 

- `linuxnode.debian.module.psm1`
- `linuxnode.ubuntu.module.psm1`

by calling the methods

`Set-UpComputerWithSpecificOsBeforeProvisioning`
`Set-UpComputerWithSpecificOsAfterProvisioning`

that are implemented in the specialization modules.

Since the test suite is tested in isolation those methods are not present.

**Solution:**
Define the methods in the test suite to satisfy the dependency.
