### PR TITLE
Fix Linuxonly tests failing because of reset win storage test

### DIFF
--- a/test/e2e/cli/cmd/image/setuprequired/systemrunning/image_system-running_test.go
+++ b/test/e2e/cli/cmd/image/setuprequired/systemrunning/image_system-running_test.go
@@ -68,7 +68,7 @@ var _ = Describe("image reset-win-storage", func() {
 			Skip("Multi-vm")
 		}
 
-		output := suite.K2sCli().Run(ctx, "image", "reset-win-storage")
+		output := suite.K2sCli().RunWithExitCode(ctx, -1, "image", "reset-win-storage")
 
 		Expect(output).To(ContainSubstring("Resetting WinContainerStorage for linux-only setup is not supported!"))
 	})


### PR DESCRIPTION
Fix Linuxonly tests failing because of reset win storage test