### PR TITLE
fix (#176): Fixes test case 'prints reinstall cluster message' in MultiVM

### DIFF
--- a/lib/modules/k2s/k2s.cluster.module/k8s-api/k8s-api.module.psm1
+++ b/lib/modules/k2s/k2s.cluster.module/k8s-api/k8s-api.module.psm1
@@ -188,7 +188,7 @@ function Get-Node {
 
     $status = Get-NodeStatus -Conditions $JsonNode.status.conditions
     $role = Get-NodeRole -Labels $JsonNode.metadata.labels
-    $age = Get-Age -Timestamp $JsonNode.metadata.creationTimestamp
+    $age = Get-Age -Timestamp $($JsonNode.metadata.creationTimestamp).ToString()
     $internalIp = Get-NodeInternalIp -Addresses $JsonNode.status.addresses
 
     return New-Object Node -Property @{
@@ -271,7 +271,7 @@ function Get-Pod {
     Write-Log "[$script::$function] Extracting Pod info from JSON.."
 
     $status = Get-PodStatus -JsonNode $JsonNode
-    $age = Get-Age -Timestamp $JsonNode.metadata.creationTimestamp
+    $age = Get-Age -Timestamp $($JsonNode.metadata.creationTimestamp).ToString()
 
     return New-Object Pod -Property @{
         Status    = $status.StatusText;

--- a/test/e2e/cli/cmd/image/setuprequired/systemrunning/image_system-running_test.go
+++ b/test/e2e/cli/cmd/image/setuprequired/systemrunning/image_system-running_test.go
@@ -54,7 +54,7 @@ var _ = Describe("image reset-win-storage", func() {
 			Skip("Linux-only")
 		}
 
-		output := suite.K2sCli().Run(ctx, "image", "reset-win-storage")
+		output := suite.K2sCli().RunWithExitCode(ctx, k2s.ExitCodeFailure, "image", "reset-win-storage")
 
 		Expect(output).To(ContainSubstring("In order to clean up WinContainerStorage for multi-vm, please reinstall multi-vm cluster!"))
 	})


### PR DESCRIPTION
The test case '_prints reinstall cluster message_' checked for the return exit code '_0_'.
Since the call `k2s.exe image reset-win-storage` is not supported in multivm the command returns '_1_' because an error message with a hint for the user is displayed.
The test case was changed to check for the exit code '_1_'

Additionally I had a problem on my machine when the prechecks for the state of the running nodes was made. The call `kubectl get nodes -o json` returns information about the nodes. It is then converted to an object. On my machine the field `$jsonObject.item[0].metadata.creationTimestamp` was of type 'DateTime' (instead of string) and when converted automatically to string (through its usage as argument in a method call) the wrong culture was picked, thus leading to a runtime error on conversion from string to 'DateTime' (because the local culture settings are used). I fixed it by calling the method `ToString()` in the object `$jsonObject.item[0].metadata.creationTimestamp` thus ensuring the usage of the local culture.