### PR TITLE
#29 refactor([CLI] psexecutor): lines from stderr stream are buffered up to a max before getting flushed to file

### DIFF
--- a/pkg/k2s/utils/logging/logbuffer.go
+++ b/pkg/k2s/utils/logging/logbuffer.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText:  © 2023 Siemens Healthcare GmbH
+// SPDX-License-Identifier:   MIT
+
+package logging
+
+import (
+	"errors"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+type BufferConfig struct {
+	Limit     uint
+	FlushFunc func(args ...any)
+}
+
+type logBuffer struct {
+	buffer []string
+	config BufferConfig
+}
+
+func NewLogBuffer(config BufferConfig) (*logBuffer, error) {
+	if config.Limit == 0 {
+		return nil, errors.New("buffer limit must be greater than 0")
+	}
+	if config.FlushFunc == nil {
+		return nil, errors.New("flush function must not be nil")
+	}
+
+	return &logBuffer{
+		buffer: []string{},
+		config: config,
+	}, nil
+}
+
+func (e *logBuffer) Log(line string) {
+	e.buffer = append(e.buffer, line)
+
+	if len(e.buffer) >= int(e.config.Limit) {
+		klog.V(8).InfoS("log buffer limit reached, flushing the buffer", "limit", e.config.Limit)
+
+		e.Flush()
+	}
+}
+
+func (e *logBuffer) Flush() {
+	if len(e.buffer) > 0 {
+		e.config.FlushFunc(squash(e.buffer))
+
+		e.buffer = []string{}
+	}
+}
+
+func squash(lines []string) string {
+	return strings.Join(lines, "\n")
+}

--- a/pkg/k2s/utils/logging/logging_test.go
+++ b/pkg/k2s/utils/logging/logging_test.go
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText:  © 2023 Siemens Healthcare GmbH
+// SPDX-License-Identifier:   MIT
+
+package logging_test
+
+import (
+	r "test/reflection"
+	"testing"
+
+	sut "k2s/utils/logging"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/klog/v2"
+)
+
+type mockObject struct {
+	mock.Mock
+}
+
+func (m *mockObject) Flush(args ...any) {
+	m.Called(args...)
+}
+
+func TestLogging(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "logging Unit Tests", Label("unit", "ci"))
+}
+
+var _ = BeforeSuite(func() {
+	klog.SetLogger(GinkgoLogr)
+})
+
+var _ = Describe("logBuffer", func() {
+	Describe("NewLogBuffer", func() {
+		When("buffer limit is 0", func() {
+			It("returns error", func() {
+				config := sut.BufferConfig{
+					Limit: 0,
+				}
+
+				result, err := sut.NewLogBuffer(config)
+
+				Expect(result).To(BeNil())
+				Expect(err).To(MatchError(ContainSubstring("limit must be greater than 0")))
+			})
+		})
+
+		When("flush function is nil", func() {
+			It("returns error", func() {
+				config := sut.BufferConfig{
+					Limit: 1,
+				}
+
+				result, err := sut.NewLogBuffer(config)
+
+				Expect(result).To(BeNil())
+				Expect(err).To(MatchError(ContainSubstring("flush function must not be nil")))
+			})
+		})
+
+		When("config is valid", func() {
+			It("returns buffer", func() {
+				config := sut.BufferConfig{
+					Limit: 1,
+					FlushFunc: func(args ...any) {
+						// empty
+					},
+				}
+
+				result, err := sut.NewLogBuffer(config)
+
+				Expect(result).ToNot(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Log", func() {
+		When("buffer limit is not reached", func() {
+			It("log line is written to buffer only", func() {
+				flushMock := &mockObject{}
+				flushMock.On(r.GetFunctionName(flushMock.Flush), mock.Anything)
+
+				config := sut.BufferConfig{
+					Limit:     4,
+					FlushFunc: flushMock.Flush,
+				}
+
+				logger, err := sut.NewLogBuffer(config)
+
+				Expect(err).ToNot(HaveOccurred())
+
+				logger.Log("a")
+				logger.Log("b")
+				logger.Log("c")
+
+				flushMock.AssertNotCalled(GinkgoT(), r.GetFunctionName(flushMock.Flush), mock.Anything)
+
+				logger.Flush()
+
+				flushMock.AssertCalled(GinkgoT(), r.GetFunctionName(flushMock.Flush), mock.Anything)
+			})
+		})
+
+		When("buffer limit is reached", func() {
+			It("log line is written to buffer and buffer is flushed", func() {
+				flushMock := &mockObject{}
+				flushMock.On(r.GetFunctionName(flushMock.Flush), mock.Anything)
+
+				config := sut.BufferConfig{
+					Limit:     3,
+					FlushFunc: flushMock.Flush,
+				}
+
+				logger, err := sut.NewLogBuffer(config)
+
+				Expect(err).ToNot(HaveOccurred())
+
+				logger.Log("a")
+				logger.Log("b")
+
+				flushMock.AssertNotCalled(GinkgoT(), r.GetFunctionName(flushMock.Flush), mock.Anything)
+
+				logger.Log("c")
+
+				flushMock.AssertCalled(GinkgoT(), r.GetFunctionName(flushMock.Flush), mock.Anything)
+			})
+		})
+	})
+
+	Describe("Flush", func() {
+		It("flushes the content in correct format and emties the buffer", func() {
+			flushMock := &mockObject{}
+			flushMock.On(r.GetFunctionName(flushMock.Flush), mock.Anything)
+
+			config := sut.BufferConfig{
+				Limit:     4,
+				FlushFunc: flushMock.Flush,
+			}
+
+			logger, err := sut.NewLogBuffer(config)
+
+			Expect(err).ToNot(HaveOccurred())
+
+			logger.Log("a")
+			logger.Log("b")
+			logger.Log("c")
+
+			flushMock.AssertNotCalled(GinkgoT(), r.GetFunctionName(flushMock.Flush), mock.Anything)
+
+			logger.Flush()
+
+			flushMock.AssertCalled(GinkgoT(), r.GetFunctionName(flushMock.Flush), mock.MatchedBy(func(squashedResult string) bool {
+				return squashedResult == "a\nb\nc"
+			}))
+
+			flushMock.Calls = []mock.Call{}
+
+			logger.Flush()
+
+			flushMock.AssertNotCalled(GinkgoT(), r.GetFunctionName(flushMock.Flush), mock.Anything)
+		})
+	})
+})


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->