### PR TITLE
Improved reset-win-storage output

### DIFF
--- a/smallsetup/helpers/CleanupContainerStorage.ps1
+++ b/smallsetup/helpers/CleanupContainerStorage.ps1
@@ -35,21 +35,30 @@ Param(
     [parameter(Mandatory = $true, HelpMessage = 'Docker directory to clean up')]
     [string] $Directory = 'd:\docker1'
 )
+
+&$PSScriptRoot\..\common\GlobalVariables.ps1
+. $PSScriptRoot\..\common\GlobalFunctions.ps1
+
+$logModule = "$PSScriptRoot\..\ps-modules\log\log.module.psm1"
+Import-Module $logModule -DisableNameChecking
+
+Initialize-Logging -ShowLogs:$ShowLogs
+
 $ErrorActionPreference = 'Continue'
 if ($Trace) {
     Set-PSDebug -Trace 1
 }
 
-Write-Host "Take ownership now on items in dir: $Directory"
-takeown /a /r /d Y /F $Directory 2>&1 | Write-Host
+Write-Log "Take ownership now on items in dir: $Directory" -Console
+takeown /a /r /d Y /F $Directory 2>&1 | Write-Log -Console
 
-Write-Host "Add ownership also for Administrators"
-icacls $Directory /grant Administrators:F /t /C 2>&1 | Write-Host
+Write-Log "Add ownership also for Administrators" -Console
+icacls $Directory /grant Administrators:F /t /C 2>&1 | Write-Log -Console
 
-Write-Host "Delete reparse points in the directory: $Directory"
-Get-ChildItem -Path $Directory -Force -Recurse -Attributes Reparsepoint -ErrorAction 'silentlycontinue' | % { $n = $_.FullName.Trim('\'); fsutil reparsepoint delete "$n" }
+Write-Log "Delete reparse points in the directory: $Directory" -Console
+Get-ChildItem -Path $Directory -Force -Recurse -Attributes Reparsepoint -ErrorAction 'silentlycontinue' | % { $n = $_.FullName.Trim('\'); fsutil reparsepoint delete "$n" 2>&1 | Write-Log -Console }
 
-Write-Host "Remove items from: $Directory"
+Write-Log "Remove items from: $Directory" -Console
 remove-item -path $Directory -Force -Recurse -ErrorAction 'silentlycontinue'
 
-Write-Host "Cleanup finished"
+Write-Log "Cleanup finished" -Console

--- a/smallsetup/helpers/CleanupContainerStorage.ps1
+++ b/smallsetup/helpers/CleanupContainerStorage.ps1
@@ -41,15 +41,15 @@ if ($Trace) {
 }
 
 Write-Host "Take ownership now on items in dir: $Directory"
-takeown /a /r /d Y /F $Directory
+takeown /a /r /d Y /F $Directory 2>&1 | Write-Host
 
 Write-Host "Add ownership also for Administrators"
-icacls $Directory /grant Administrators:F /t /C
+icacls $Directory /grant Administrators:F /t /C 2>&1 | Write-Host
 
 Write-Host "Delete reparse points in the directory: $Directory"
 Get-ChildItem -Path $Directory -Force -Recurse -Attributes Reparsepoint -ErrorAction 'silentlycontinue' | % { $n = $_.FullName.Trim('\'); fsutil reparsepoint delete "$n" }
 
 Write-Host "Remove items from: $Directory"
-remove-item -path $Directory -Force -Recurse
+remove-item -path $Directory -Force -Recurse -ErrorAction 'silentlycontinue'
 
 Write-Host "Cleanup finished"

--- a/smallsetup/helpers/ResetWinContainerStorage.ps1
+++ b/smallsetup/helpers/ResetWinContainerStorage.ps1
@@ -59,7 +59,7 @@ function Get-DockerStatus() {
     return $false
 }
 
-function Perform-CleanupOfContainerStorage([string]$Directory, [int]$MaxRetries, [bool]$ForceZap) {
+function Invoke-CleanupOfContainerStorage([string]$Directory, [int]$MaxRetries, [bool]$ForceZap) {
     $successfulDirectoryCleanup = $false
     for ($i = 0; $i -lt $MaxRetries; $i++) {
         &$PSScriptRoot\CleanupContainerStorage.ps1 -Directory $Directory
@@ -146,13 +146,13 @@ if ($dockerRunningStatus) {
 $cleanUpWasPerformed = $false
 if (Test-Path $Containerd) {
     Write-Log "Performing cleanup of $Containerd" -Console
-    Perform-CleanupOfContainerStorage -Directory $Containerd -MaxRetries $MaxRetries -ForceZap $ForceZap
+    Invoke-CleanupOfContainerStorage -Directory $Containerd -MaxRetries $MaxRetries -ForceZap $ForceZap
     $cleanUpWasPerformed = $true
 }
 
 if (Test-Path $Docker) {
     Write-Log "Performing cleanup of $Docker" -Console
-    Perform-CleanupOfContainerStorage -Directory $Docker -MaxRetries $MaxRetries -ForceZap $ForceZap
+    Invoke-CleanupOfContainerStorage -Directory $Docker -MaxRetries $MaxRetries -ForceZap $ForceZap
     $cleanUpWasPerformed = $true
 }
 

--- a/smallsetup/helpers/ResetWinContainerStorage.ps1
+++ b/smallsetup/helpers/ResetWinContainerStorage.ps1
@@ -75,7 +75,7 @@ function Invoke-CleanupOfContainerStorage([string]$Directory, [int]$MaxRetries, 
     if (!$successfulDirectoryCleanup) {
         if ($ForceZap) {
             Write-Log 'Directory could not be cleaned up after exhausting all retries. Will zap it using zap.exe' -Console
-            &$global:BinPath\zap.exe -folder $Directory
+            &$global:BinPath\zap.exe -folder $Directory 2>&1 | Write-Log
             if (Test-Path $Directory) {
                 Write-Error "Directory $Directory could not be successfully deleted. Please try again."
             }

--- a/smallsetup/windowsnode/publisher/PublishWindowsImages.ps1
+++ b/smallsetup/windowsnode/publisher/PublishWindowsImages.ps1
@@ -21,10 +21,10 @@ function PublishWindowsImages($baseDirectory) {
     foreach ($file in $files){
         $fileFullName = $file.FullName
         Write-Log "Import image from file '$fileFullName'... ($fileIndex of $amountOfFiles)"
-        &$global:CtrExe -n="k8s.io" images import `"$file`"
-        if (!$?) {
-            throw "The file '$fileFullName' could not be imported"
-        }
+        #&$global:CtrExe -n="k8s.io" images import `"$file`"
+        #if (!$?) {
+        #    throw "The file '$fileFullName' could not be imported"
+        #}
         Write-Log "  done"
         $fileIndex++
     }


### PR DESCRIPTION
- Redirected all logs from icacls and takeown commands to k2s cli log so it is possible to determine which files/folders could not deleted.
- The command by default asks for user confirmation before triggering this operation. The prompt can be bypassed by providing the ***-f*** or ***--force*** options.
- The force-zap flag has now a new shorthand ***-z*** as ***-f*** is now used by force.