### PR TITLE
fixes https://github.com/Siemens-Healthineers/K2s/issues/367

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [Features](/doc/K8s_Features.md) for a full list of features.
 
 ## Quickstart
 
-Extract the downloaded [K2s.zip](https://github.com/Siemens-Healthineers/K2s/releases) file to a folder of your choice (use **C:** drive if possible), open a command prompt as Administrator and navigate to the installation folder.
+Get **K2s** into a folder of your choice as [described here](doc/K8s_Get-K2s.md) (use **C:** drive if possible), open a command prompt as Administrator and navigate to the installation folder.
 
 Install **K2s** with (ensure to verify the [Prerequisites](./doc/k2scli/install-uninstall_cmd.md#prerequisites) first):
 ```

--- a/doc/K8s_Get-K2s.md
+++ b/doc/K8s_Get-K2s.md
@@ -20,7 +20,7 @@ The **recommended** way of installing K2s is using our latest, officially cleare
 
 ## 1. Download
 You can download the latest version from the following location: 
-- [**K2s** Downloads](https://github.com/Siemens-Healthineers/K2s) 
+- [**K2s** Releases](https://github.com/Siemens-Healthineers/K2s/releases)
 
 **NOTE:** Please make sure you ckeck *Unblock* in file properties before extracting zip file in case this option is available: 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH

SPDX-License-Identifier: MIT
-->
Fixes https://github.com/Siemens-Healthineers/K2s/issues/367

### Motivation
When following the Quickstart in README.md, users miss to unblock the downloaded ZIP file and run into problems.

### Modifications

- README.md links now to the "How to Get" instructions, where the procedure is described in detail
- The link to the Releases in How to Get was broken, and is now pointing to the Releases
 
### Verification

n.a.