### PR TITLE
#348 refactor(install): Uses module to set environment paths

### DIFF
--- a/smallsetup/InstallK8s.ps1
+++ b/smallsetup/InstallK8s.ps1
@@ -87,9 +87,10 @@ Param(
 
 $logModule = "$PSScriptRoot\ps-modules\log\log.module.psm1"
 $proxyModule = "$PSScriptRoot\ps-modules\proxy\proxy.module.psm1"
+$temporaryPathModule = "$PSScriptRoot\ps-modules\only-while-refactoring\installation\still-to-merge.path.module.psm1"
 $systemModule = "$PSScriptRoot\..\lib\modules\k2s\k2s.node.module\windowsnode\system\system.module.psm1"
 
-Import-Module $logModule, $systemModule, $proxyModule
+Import-Module $logModule, $systemModule, $proxyModule, $temporaryPathModule
 
 Initialize-Logging -ShowLogs:$ShowLogs
 
@@ -119,7 +120,7 @@ if ( $MasterDiskSize -lt 50GB ) {
 }
 Write-Log "Using Master VM Diskspace: $([math]::round($MasterDiskSize/1GB, 2))GB"
 
-Set-EnvVars
+Set-EnvironmentPaths
 
 $Proxy = Get-OrUpdateProxyServer -Proxy:$Proxy
 
@@ -380,5 +381,5 @@ Write-Log '---------------------------------------------------------------'
 Write-Log "K2s setup finished.   Total duration: $('{0:hh\:mm\:ss}' -f $installStopwatch.Elapsed )"
 Write-Log '---------------------------------------------------------------'
 
-Write-RefreshEnvVariables
+Write-RefreshEnvironmentPathsMessage
 

--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.path.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.path.module.psm1
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
+# SPDX-License-Identifier: MIT
+
+$logModule = "$PSScriptRoot\..\..\log\log.module.psm1"
+
+Import-Module $logModule
+
+function GetKubePath {
+    $scriptRoot = $PSScriptRoot
+    $kubePath = (Get-Item $scriptRoot).Parent.Parent.Parent.Parent.FullName
+    return $kubePath
+}
+
+function UpdateSystemPath ($Action, $Addendum) {
+    $regLocation = 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment'
+    $path = (Get-ItemProperty -Path $regLocation -Name PATH).path
+
+    # Add an item to PATH
+    if ($Action -eq 'add') {
+        $path = $path + [IO.Path]::PathSeparator + $Addendum
+        $path = ( $path -split [IO.Path]::PathSeparator | Select-Object -Unique ) -join [IO.Path]::PathSeparator
+        Set-ItemProperty -Path $regLocation -Name PATH -Value $path
+
+        $env:Path = $env:Path + [IO.Path]::PathSeparator + $Addendum
+        $env:Path = ( $env:Path -split [IO.Path]::PathSeparator | Select-Object -Unique ) -join [IO.Path]::PathSeparator
+
+        Write-Verbose "Added $Addendum to PATH variable"
+    }
+
+    # Remove an item from PATH
+    if ($Action -eq 'remove') {
+        $path = ($path.Split([IO.Path]::PathSeparator) | Where-Object { $_ -ne "$Addendum" }) -join [IO.Path]::PathSeparator
+        Set-ItemProperty -Path $regLocation -Name PATH -Value $path
+    }
+}
+
+function Set-EnvironmentPaths {
+    $kubePath = GetKubePath
+    UpdateSystemPath -Action 'add' "$kubePath"
+    UpdateSystemPath -Action 'add' "$kubePath\bin"
+    UpdateSystemPath -Action 'add' "$kubePath\bin\exe"
+    UpdateSystemPath -Action 'add' "$kubePath\bin\docker"
+    UpdateSystemPath -Action 'add' "$kubePath\bin\containerd"
+}
+
+function Reset-EnvironmentPaths {
+    UpdateSystemPath -Action 'remove' "$kubePath"
+    UpdateSystemPath -Action 'remove' "$kubePath\bin"
+    UpdateSystemPath -Action 'remove' "$kubePath\bin\exe"
+    UpdateSystemPath -Action 'remove' "$kubePath\bin\docker"
+    UpdateSystemPath -Action 'remove' "$kubePath\containerd" # Backward compatibility
+    UpdateSystemPath -Action 'remove' "$kubePath\bin\containerd"
+}
+
+function Write-RefreshEnvironmentPathsMessage {
+    Write-Log ' ' -Console
+    Write-Log '   Update PATH environment variable for proper usage:' -Console
+    Write-Log ' ' -Console
+    Write-Log "   Powershell: '$global:KubernetesPath\smallsetup\helpers\RefreshEnv.ps1'" -Console
+    Write-Log "   Command Prompt: '$global:KubernetesPath\smallsetup\helpers\RefreshEnv.cmd'" -Console
+    Write-Log '   Or open new shell' -Console
+    Write-Log ' ' -Console
+}
+
+Export-ModuleMember -Function Set-EnvironmentPaths, Reset-EnvironmentPaths, Write-RefreshEnvironmentPathsMessage


### PR DESCRIPTION
A temporary module was created to set the environment paths and is used in the InstallK8s.ps1 script.
The current available module could not be used since it has equally named methods as the file GlobalFunctions.ps1 thus leading to superseeding effects. Once the file GlobalFunctions.ps1 is not called anymore from InstallK8s.ps1 the usage of the temporary module will be discontinued.