### PR TITLE
#348 refactor(install): Uses existing system module to add k2s to defender exclusion

### DIFF
--- a/smallsetup/InstallK8s.ps1
+++ b/smallsetup/InstallK8s.ps1
@@ -124,7 +124,7 @@ Set-EnvironmentPaths
 
 $Proxy = Get-OrUpdateProxyServer -Proxy:$Proxy
 
-Addk2sToDefenderExclusion
+Add-K2sToDefenderExclusion
 
 Stop-InstallationIfDockerDesktopIsRunning
 


### PR DESCRIPTION
Uses the existing method in the system module to add k2s to the defender exclusion.