### PR TITLE
#348 refactor(install): Uses the system module to check if docker destop is installed

### DIFF
--- a/smallsetup/InstallK8s.ps1
+++ b/smallsetup/InstallK8s.ps1
@@ -126,7 +126,7 @@ $Proxy = Get-OrUpdateProxyServer -Proxy:$Proxy
 
 Add-K2sToDefenderExclusion
 
-Stop-InstallationIfDockerDesktopIsRunning
+Stop-InstallIfDockerDesktopIsRunning
 
 if ( $K8sSetup -eq 'SmallSetup' ) {
     Write-Log 'Installing K2s'


### PR DESCRIPTION
Uses the existing system module to check if docker desktop is installed on the Windows host where the installation will be done.