### PR TITLE
#348 refactor(install): Uses temporary added path module to get the installation path

### DIFF
--- a/smallsetup/InstallK8s.ps1
+++ b/smallsetup/InstallK8s.ps1
@@ -147,7 +147,8 @@ $global:HeaderLineShown = $true
 ################################ SCRIPT START ###############################################
 
 # make sure we are at the right place for install
-Set-Location $global:KubernetesPath
+$kubePath = Get-InstallationPath
+Set-Location $kubePath
 
 # set defaults for unset arguments
 $KubernetesVersion = $global:KubernetesVersion

--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.path.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.path.module.psm1
@@ -5,6 +5,11 @@ $logModule = "$PSScriptRoot\..\..\log\log.module.psm1"
 
 Import-Module $logModule
 
+function Get-InstallationPath {
+    $installationPath = GetKubePath
+    return $installationPath
+}
+
 function GetKubePath {
     $scriptRoot = $PSScriptRoot
     $kubePath = (Get-Item $scriptRoot).Parent.Parent.Parent.Parent.FullName
@@ -62,4 +67,4 @@ function Write-RefreshEnvironmentPathsMessage {
     Write-Log ' ' -Console
 }
 
-Export-ModuleMember -Function Set-EnvironmentPaths, Reset-EnvironmentPaths, Write-RefreshEnvironmentPathsMessage
+Export-ModuleMember -Function Set-EnvironmentPaths, Reset-EnvironmentPaths, Write-RefreshEnvironmentPathsMessage, Get-InstallationPath


### PR DESCRIPTION
Uses the temporary added path module to get the installation path. The existing path module was not used because it was not referenced in InstallK8s.ps1 and adding its reference would have superseeded methods in GlobalFunctions.ps1 that are not in relation with the intended change.