### PR TITLE
#348 refactor(install): Uses module to get the kubernetes version

### DIFF
--- a/smallsetup/InstallK8s.ps1
+++ b/smallsetup/InstallK8s.ps1
@@ -88,9 +88,10 @@ Param(
 $logModule = "$PSScriptRoot\ps-modules\log\log.module.psm1"
 $proxyModule = "$PSScriptRoot\ps-modules\proxy\proxy.module.psm1"
 $temporaryPathModule = "$PSScriptRoot\ps-modules\only-while-refactoring\installation\still-to-merge.path.module.psm1"
+$temporaryConfigModule = "$PSScriptRoot\ps-modules\only-while-refactoring\installation\still-to-merge.config.module.psm1"
 $systemModule = "$PSScriptRoot\..\lib\modules\k2s\k2s.node.module\windowsnode\system\system.module.psm1"
 
-Import-Module $logModule, $systemModule, $proxyModule, $temporaryPathModule
+Import-Module $logModule, $systemModule, $proxyModule, $temporaryPathModule, $temporaryConfigModule
 
 Initialize-Logging -ShowLogs:$ShowLogs
 
@@ -151,10 +152,7 @@ $kubePath = Get-InstallationPath
 Set-Location $kubePath
 
 # set defaults for unset arguments
-$KubernetesVersion = $global:KubernetesVersion
-if (! $KubernetesVersion) {
-    $KubernetesVersion = 'v1.25.13'
-}
+$KubernetesVersion = Get-KubernetesVersion
 
 # check prerequisites
 Write-Log 'Running some health checks before installation...'

--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.config.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.config.module.psm1
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
+# SPDX-License-Identifier: MIT
+
+function Get-KubernetesVersion {
+    return 'v1.25.13'
+}
+
+Export-ModuleMember -Function Get-KubernetesVersion


### PR DESCRIPTION
A temporary module was created to get the kubernetes version and is used in the InstallK8s.ps1 script.
The current available module could not be used since it has equally named methods as the file GlobalFunctions.ps1 thus leading to superseeding effects. Once the file GlobalFunctions.ps1 is not called anymore from InstallK8s.ps1 the usage of the temporary module will be discontinued.