### PR TITLE
#348 refactor(install): Uses module to set and get config values

### DIFF
--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.config.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.config.module.psm1
@@ -1,8 +1,31 @@
 # SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
 # SPDX-License-Identifier: MIT
 
+$configModule = "$PSScriptRoot\..\..\..\..\lib\modules\k2s\k2s.infra.module\config\config.module.psm1"
+
+Import-Module $configModule
+
 function Get-KubernetesVersion {
-    return 'v1.25.13'
+    return Get-DefaultK8sVersion
 }
 
-Export-ModuleMember -Function Get-KubernetesVersion
+function Set-ConfigContainerdFlag {
+    param (
+        [object] $Value = $(throw 'Please provide the config value.')
+    )
+    $setupJsonFile = Get-SetupConfigFilePath
+    Set-ConfigValue -Path $setupJsonFile -Key 'UseContainerd' -Value $Value
+}
+
+function Set-ReuseExistingLinuxComputerForMasterNodeFlag {
+    param (
+        [object] $Value = $(throw 'Please provide the config value.')
+    )
+    $setupJsonFile = Get-SetupConfigFilePath
+    Set-ConfigValue -Path $setupJsonFile -Key 'ReuseExistingLinuxComputerForMasterNode' -Value $Value
+}
+
+# imported functions
+Export-ModuleMember -Function Set-ConfigWslFlag, Set-ConfigLinuxOsType, Set-ConfigSetupType 
+# new functions
+Export-ModuleMember -Function Get-KubernetesVersion, Set-ConfigContainerdFlag, Set-ReuseExistingLinuxComputerForMasterNodeFlag

--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.vm.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.vm.module.psm1
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
+# SPDX-License-Identifier: MIT
+
+$vmModule = "$PSScriptRoot\..\..\..\..\lib\modules\k2s\k2s.node.module\linuxnode\vm\vm.module.psm1"
+
+Import-Module $vmModule
+
+
+function Get-LinuxOsType_UsingModule($LinuxVhdxPath) {
+    return Get-LinuxOsType($LinuxVhdxPath) 
+}
+
+Export-ModuleMember -Function Get-LinuxOsType_UsingModule


### PR DESCRIPTION
2 temporary modules were created to set and get the config values and are used in the InstallK8s.ps1 script.
The current available modules could not be used since they have equally named methods as the file GlobalFunctions.ps1 thus leading to superseeding effects. Once the file GlobalFunctions.ps1 is not called anymore from InstallK8s.ps1 the usage of the temporary modules will be discontinued.