### PR TITLE
#348 refactor(install): Uses module to retrieve the name of the control plane VM

### DIFF
--- a/smallsetup/InstallK8s.ps1
+++ b/smallsetup/InstallK8s.ps1
@@ -193,8 +193,10 @@ if ($runningVMs) {
     }
 }
 
-if (Get-VM -ErrorAction SilentlyContinue -Name $global:VMName) {
-    throw "$global:VMName VM must not exist when running the installer, do UninstallK8s.ps1 first"
+$controlPlaneVmName = Get-ControlPlaneVmName
+
+if (Get-VM -ErrorAction SilentlyContinue -Name $controlPlaneVmName) {
+    throw "$controlPlaneVmName VM must not exist when running the installer, do UninstallK8s.ps1 first"
 }
 
 if ($CheckOnly) {
@@ -268,10 +270,10 @@ Remove-Item "$global:WindowsNodeArtifactsDirectory" -Recurse -Force -ErrorAction
 &"$global:NssmInstallDirectory\nssm" set flanneld Start SERVICE_DEMAND_START | Out-Null
 
 if ($WSL) {
-    Write-Log "Setting up $global:VMName Distro" -Console
+    Write-Log "Setting up $controlPlaneVmName Distro" -Console
 }
 else {
-    Write-Log "Setting up $global:VMName VM" -Console
+    Write-Log "Setting up $controlPlaneVmName VM" -Console
 }
 
 # create the linux master
@@ -287,7 +289,7 @@ if ($reuseExistingLinuxComputer) {
     Wait-ForSSHConnectionToLinuxVMViaSshKey
 }
 else {
-    $vm = Get-Vm -Name $global:VMName -ErrorAction SilentlyContinue
+    $vm = Get-Vm -Name $controlPlaneVmName -ErrorAction SilentlyContinue
     if ( !($vm) ) {
         # use the local httpproxy for the linux master VM
         $transparentproxy = 'http://' + $global:IP_NextHop + ':8181'

--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.vm.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.vm.module.psm1
@@ -10,4 +10,9 @@ function Get-LinuxOsType_UsingModule($LinuxVhdxPath) {
     return Get-LinuxOsType($LinuxVhdxPath) 
 }
 
-Export-ModuleMember -Function Get-LinuxOsType_UsingModule
+function Get-ControlPlaneVmName {
+    return 'KubeMaster'
+}
+
+
+Export-ModuleMember -Function Get-LinuxOsType_UsingModule, Get-ControlPlaneVmName


### PR DESCRIPTION
The name for the control plane VM is not retrieved from GlobalVariables.ps1 anymore but from a module.