### PR TITLE
#348 refactor(install): Replaces direct usage of global variables with values retrieved from modules.

### DIFF
--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.config.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.config.module.psm1
@@ -25,7 +25,15 @@ function Set-ReuseExistingLinuxComputerForMasterNodeFlag {
     Set-ConfigValue -Path $setupJsonFile -Key 'ReuseExistingLinuxComputerForMasterNode' -Value $Value
 }
 
+function Get-ControlPlaneNodeIpAddress {
+    return Get-ConfiguredIPControlPlane
+}
+
+function Get-WindowsHostClusterIpAddress {
+    return Get-ConfiguredKubeSwitchIP
+}
+
 # imported functions
-Export-ModuleMember -Function Set-ConfigWslFlag, Set-ConfigLinuxOsType, Set-ConfigSetupType 
+Export-ModuleMember -Function Set-ConfigWslFlag, Set-ConfigLinuxOsType, Set-ConfigSetupType, Get-KubernetesImagesFilePath
 # new functions
-Export-ModuleMember -Function Get-KubernetesVersion, Set-ConfigContainerdFlag, Set-ReuseExistingLinuxComputerForMasterNodeFlag
+Export-ModuleMember -Function Get-KubernetesVersion, Set-ConfigContainerdFlag, Set-ReuseExistingLinuxComputerForMasterNodeFlag, Get-ControlPlaneNodeIpAddress, Get-WindowsHostClusterIpAddress

--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.loopbackadapter.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.loopbackadapter.module.psm1
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
+# SPDX-License-Identifier: MIT
+
+$loopbackAdapterModule = "$PSScriptRoot\..\..\..\..\lib\modules\k2s\k2s.node.module\windowsnode\network\loopbackadapter.module.psm1"
+$temporaryPathModule = "$PSScriptRoot\still-to-merge.path.module.psm1"
+
+Import-Module $loopbackAdapterModule, $temporaryPathModule
+
+
+function Get-LoopbackAdapterName {
+    return Get-L2BridgeName
+}
+
+function Get-LoopbackAdapterIpAddress {
+    return Get-LoopbackAdapterIP
+}
+
+function Get-LoopbackAdapterGatewayIpAddress {
+    return Get-LoopbackAdapterGateway
+}
+
+function Get-LoopbackAdapterExecutable {
+    return "$(Get-InstallationPath)\bin\devgon.exe"
+}
+
+Export-ModuleMember -Function Get-LoopbackAdapterName, Get-LoopbackAdapterIpAddress, Get-LoopbackAdapterGatewayIpAddress, Get-LoopbackAdapterExecutable 

--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.path.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.path.module.psm1
@@ -10,6 +10,25 @@ function Get-InstallationPath {
     return $installationPath
 }
 
+function Get-BinPath {
+    $installationPath = GetKubePath
+    return "$installationPath\bin"
+}
+
+function Get-ExecutablesPath {
+    $binPath = Get-BinPath
+    return "$binPath\exe"
+}
+
+function Get-DockerPath {
+    $binPath = Get-BinPath
+    return "$binPath\docker"
+}
+
+function Get-SystemDriveLetter {
+    return 'C'
+}
+
 function GetKubePath {
     $scriptRoot = $PSScriptRoot
     $kubePath = (Get-Item $scriptRoot).Parent.Parent.Parent.Parent.FullName
@@ -67,4 +86,4 @@ function Write-RefreshEnvironmentPathsMessage {
     Write-Log ' ' -Console
 }
 
-Export-ModuleMember -Function Set-EnvironmentPaths, Reset-EnvironmentPaths, Write-RefreshEnvironmentPathsMessage, Get-InstallationPath
+Export-ModuleMember -Function Set-EnvironmentPaths, Reset-EnvironmentPaths, Write-RefreshEnvironmentPathsMessage, Get-InstallationPath, Get-BinPath, Get-ExecutablesPath, Get-SystemDriveLetter, Get-DockerPath

--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.windowsnode.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.windowsnode.module.psm1
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
+# SPDX-License-Identifier: MIT
+
+$temporaryPathModule = "$PSScriptRoot\still-to-merge.path.module.psm1"
+
+Import-Module $temporaryPathModule
+
+function Get-WindowsNodeArtifactsDirectory {
+    return "$(Get-InstallationPath)\bin\windowsnode"
+}
+
+
+function Get-KubeletConfigDirectory {
+    return "$(Get-SystemDriveLetter):\var\lib\kubelet"
+}
+
+function Get-KubectlExecutable {
+    return "$(Get-ExecutablesPath)\kubectl.exe"
+}
+
+function Get-DockerExecutable {
+    return "$(Get-DockerPath)\docker.exe"
+}
+
+Export-ModuleMember -Function Get-WindowsNodeArtifactsDirectory, Get-KubeletConfigDirectory, Get-KubectlExecutable, Get-DockerExecutable


### PR DESCRIPTION
2 temporary modules were created to retrieve the values provided by the directly used global variables and are used in the InstallK8s.ps1 script.
The current available modules could not be used since they have equally named methods as the file GlobalFunctions.ps1 thus leading to superseeding effects. Once the file GlobalFunctions.ps1 is not called anymore from InstallK8s.ps1 the usage of the temporary modules will be discontinued.