### PR TITLE
#348 refactor(install): Removes calls to StartK8s.ps1 and StopK8s.ps1 through isolation module

### DIFF
--- a/smallsetup/InstallK8s.ps1
+++ b/smallsetup/InstallK8s.ps1
@@ -184,7 +184,7 @@ Initialize-KubernetesCluster -AdditionalHooksDir $AdditionalHooksDir
 
 if (! $SkipStart) {
     Write-Log 'Starting Kubernetes System'
-    Invoke-Script_StartK8s -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay
+    & "$PSScriptRoot\StartK8s.ps1" -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay
 
     if ($RestartAfterInstallCount -gt 0) {
         $restartCount = 0;
@@ -193,10 +193,10 @@ if (! $SkipStart) {
             $restartCount++
             Write-Log "Restarting Kubernetes System (iteration #$restartCount):"
     
-            Invoke-Script_StopK8s -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs
+            & "$PSScriptRoot\StopK8s.ps1" -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay
             Start-Sleep 10 # Wait for renew of IP
     
-            Invoke-Script_StartK8s -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay
+            & "$PSScriptRoot\StartK8s.ps1" -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay
             Start-Sleep -s 5
     
             if ($restartCount -eq $RestartAfterInstallCount) {
@@ -211,7 +211,7 @@ if (! $SkipStart) {
     Start-Sleep 2
     &$kubectlExe get nodes -o wide
 } else {
-    Invoke-Script_StopK8s -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs
+    & "$PSScriptRoot\StopK8s.ps1" -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay
 }
 
 Invoke-Hook -HookName 'AfterBaseInstall' -AdditionalHooksDir $AdditionalHooksDir

--- a/smallsetup/UninstallK8s.ps1
+++ b/smallsetup/UninstallK8s.ps1
@@ -18,7 +18,7 @@ Param(
     [string] $AdditionalHooksDir = '',
     [parameter(Mandatory = $false, HelpMessage = 'Deletes the needed files to perform an offline installation')]
     [switch] $DeleteFilesForOfflineInstallation = $false,
-    [parameter(Mandatory = $false, HelpMessage = 'Skips showing start header display')]
+    [parameter(Mandatory = $false, HelpMessage = 'Skips showing uninstall header display')]
     [switch] $SkipHeaderDisplay = $false
 )
 

--- a/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.isolatedcalledscripts.module.psm1
+++ b/smallsetup/ps-modules/only-while-refactoring/installation/still-to-merge.isolatedcalledscripts.module.psm1
@@ -32,22 +32,6 @@ function Invoke-Script_ExistingUbuntuComputerAsMasterNodeInstaller {
     &"$installationPath\smallsetup\linuxnode\ubuntu\ExistingUbuntuComputerAsMasterNodeInstaller.ps1" -IpAddress $IpAddress -UserName $UserName -UserPwd $UserPwd -Proxy $Proxy
 }
 
-function Invoke-Script_StartK8s {
-    Param(
-        [switch] $ShowLogs = $false,
-        [string] $AdditionalHooksDir = ''
-    )
-    & "$installationPath\smallsetup\StartK8s.ps1" -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs
-}
-
-function Invoke-Script_StopK8s {
-    Param(
-        [switch] $ShowLogs = $false,
-        [string] $AdditionalHooksDir = ''
-    )
-    & "$installationPath\smallsetup\StopK8s.ps1" -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs
-}
-
 function Invoke-Script_UninstallKubeMaster {
     Param(
         [Boolean] $DeleteFilesForOfflineInstallation = $false
@@ -57,8 +41,6 @@ function Invoke-Script_UninstallKubeMaster {
 
 Export-ModuleMember -Function Set-InstallationPathIntoScriptsIsolationModule, Set-LoggingPreferencesIntoScriptsIsolationModule,  
 Invoke-Script_ExistingUbuntuComputerAsMasterNodeInstaller,
-Invoke-Script_StartK8s,
-Invoke-Script_StopK8s,
 Invoke-Script_UninstallKubeMaster
 
 


### PR DESCRIPTION
The scripts StartK8s.ps1 and StopK8s.ps1 do not use GlobalVariables.ps1 nor GlobalFunctions.ps1 anymore, therefore the call to them from InstallK8s.ps1 through the isolation module has been removed and are called directly again.