### PR TITLE
central ingress tls

### DIFF
--- a/addons/dashboard/manifests/dashboard-nginx-ingress.yaml
+++ b/addons/dashboard/manifests/dashboard-nginx-ingress.yaml
@@ -2,16 +2,29 @@
 #
 # SPDX-License-Identifier: MIT
 
+# The kubernetes-dashboard service exposes an angular application on port 443
+# The angular application is design in such a way that it constructs the 
+# relative paths based on the value stored in the x-forwarded-prefix header
+# of the request. So if the application is exposed on another path than root,
+# this header must have as value that path.
 ---
+# This ingress will expose the angular application on:
+# HTTP: http://k2s-dashboard.local 
+# TLS: https://k2s-dashboard.local 
+# For TLS, the certificate is taken from k8s secret 'k2s-dashboard-local-tls'
+# This secret will be created by cert-manager, if it is installed and running.
+# If cert-manager is not installed, the secret will not be present and nginx 
+# will use an own self-signed certificate.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: dashboard-nginx-local
+  namespace: kubernetes-dashboard
   annotations:
     cert-manager.io/cluster-issuer: k2s-ca-issuer
     cert-manager.io/common-name: k2s-dashboard.local
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-  name: dashboard
-  namespace: kubernetes-dashboard
 spec:
   ingressClassName: nginx
   rules:
@@ -28,4 +41,36 @@ spec:
   tls:
   - hosts:
     - k2s-dashboard.local
-    secretName: dashboard-tls
+    secretName: k2s-dashboard-local-tls
+---
+# this ingress will be merged with ingress provided in:
+# addons/ingress-nginx/manifests/cluster-net-ingress.yaml
+# and exposes the kubernetes-dashboard angular application on:
+# https://k2s.cluster.net/dashboard/
+# The certificate is taken from k8s secret 'k2s.cluster.net-tls'
+# (see addons/ingress-nginx/manifests/cluster-net-ingress.yaml)
+# NOTE: there is a glitch in dashboard,
+# causing the trailing / in bot URLs to be needed, i.e.
+# https://k2s.cluster.net/dashboard will not work!
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard-nginx-cluster-net
+  namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: "/dashboard/"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: k2s.cluster.net
+      http:
+        paths:
+        - path: /dashboard/(.*)
+          pathType: Prefix
+          backend:
+            service:
+              name: kubernetes-dashboard
+              port: 
+                number: 443

--- a/addons/dashboard/manifests/dashboard-traefik-ingress.yaml
+++ b/addons/dashboard/manifests/dashboard-traefik-ingress.yaml
@@ -2,7 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
+# The kubernetes-dashboard service exposes an angular application on port 443
+# The angular application is design in such a way that it constructs the 
+# relative paths based on the value stored in the x-forwarded-prefix header
+# of the request. So if the application is exposed on another path than root,
+# this header must have as value that path.
 ---
+# This ingress will expose the angular application on:
+# HTTP: http://k2s-dashboard.local 
+# TLS: https://k2s-dashboard.local 
+# For TLS, the certificate is taken from k8s secret 'k2s-dashboard-local-tls'
+# This secret will be created by cert-manager, if it is installed and running.
+# If cert-manager is not installed, the secret will not be present and 
+# traefik will use an own self-signed certificate.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -10,7 +22,7 @@ metadata:
     cert-manager.io/cluster-issuer: k2s-ca-issuer
     cert-manager.io/common-name: k2s-dashboard.local
     traefik.ingress.kubernetes.io/router.tls: "true"
-  name: dashboard
+  name: dashboard-traefik-local
   namespace: kubernetes-dashboard
 spec:
   ingressClassName: traefik
@@ -28,4 +40,45 @@ spec:
   tls:
   - hosts:
     - k2s-dashboard.local
-    secretName: dashboard-tls
+    secretName: k2s-dashboard-local-tls
+---
+# this MiddleWare will strip the prefix /dashboard from the request path
+# and set the x-forwarded-prefix header of the request to /dashboard/
+# see https://doc.traefik.io/traefik/middlewares/http/stripprefix/
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-prefix
+  namespace: kubernetes-dashboard
+spec:
+  stripPrefix:
+    prefixes:
+      - /dashboard
+---
+# this ingress will be merged with ingress provided in:
+# addons/traefik/manifests/cluster-net-ingress.yaml
+# and exposes the kubernetes-dashboard angular application on:
+# https://k2s.cluster.net/dashboard/
+# The certificate is taken from k8s secret 'k2s.cluster.net-tls'
+# (see addons/traefik/manifests/cluster-net-ingress.yaml)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard-traefik-cluster-net
+  namespace: kubernetes-dashboard
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: kubernetes-dashboard-strip-prefix@kubernetescrd
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: k2s.cluster.net
+      http:
+        paths:
+        - path: /dashboard/
+          pathType: Prefix
+          backend:
+            service:
+              name: kubernetes-dashboard
+              port: 
+                number: 443

--- a/addons/ingress-nginx/Enable.ps1
+++ b/addons/ingress-nginx/Enable.ps1
@@ -138,6 +138,9 @@ if ($allPodsAreUp -ne $true) {
     exit 1
 }
 
+$clusterIngressConfig = "$PSScriptRoot\manifests\cluster-net-ingress.yaml"
+(Invoke-Kubectl -Params 'apply' , '-f', $clusterIngressConfig).Output | Write-Log
+
 Write-Log 'All ingress-nginx pods are up and ready.'
 
 Add-AddonToSetupJson -Addon ([pscustomobject] @{Name = 'ingress-nginx' })

--- a/addons/ingress-nginx/README.md
+++ b/addons/ingress-nginx/README.md
@@ -8,24 +8,71 @@ SPDX-License-Identifier: MIT
 
 ## Introduction
 
-The `ingress-nginx` addon provides an implementation of the [Ingress NGINX Controller](https://github.com/kubernetes/ingress-nginx). An Ingress controller acts as a reverse proxy and load balancer. It implements a Kubernetes Ingress. The ingress controller adds a layer of abstraction to traffic routing, accepting traffic from outside the Kubernetes platform and load balancing it to pods running inside the platform.
+The `ingress-nginx` addon provides an implementation of the Ingress Controller
+with [ingressClassName: nginx](https://github.com/kubernetes/ingress-nginx).
+An Ingress controller acts as a reverse proxy and load balancer.
+It implements a Kubernetes Ingress.
+The ingress controller adds a layer of abstraction to traffic routing,
+accepting traffic from outside the Kubernetes platform and load balancing
+it to pods running inside the platform.
 
 ## Getting started
 
-The ingress-nginx addon can be enabled using the k2s CLI by running the following command:
-```
+The ingress-nginx addon can be enabled using the k2s CLI
+by running the following command:
+
+```cmd
 k2s addons enable ingress-nginx
 ```
+
 ## Creating ingress routes
 
-The Ingress NGINX Controller supports standard Kubernetes networking definitions in order to reach cluster workloads. How to create an ingress route can be found [here](https://kubernetes.io/docs/concepts/services-networking/ingress/).
+The Ingress NGINX Controller supports standard Kubernetes networking
+definitions in order to reach cluster workloads.
+How to create an ingress route can be found
+[here](https://kubernetes.io/docs/concepts/services-networking/ingress/).
 
 ## Access of the ingress controller
 
-The ingress controller is configured so that it can be reached from outside the cluster via the external IP Address `172.19.1.100`.
+The ingress controller is configured so that it can be reached from outside
+the cluster via the external IP Address `172.19.1.100`.
 
-_Note:_ It is only possible to enable one ingress controller or gateway controller (ingress-nginx, traefik or gateway-nginx) in the k2s cluster at the same time since they use the same ports.
+_Note:_ It is only possible to enable one ingress controller or gateway
+controller (ingress-nginx, traefik or gateway-nginx) in the k2s cluster at the
+same time since they use the same ports.
+
+This Addon prepares one central TLS termination, matching the hostname
+`k2s.cluster.net`, and using as certificate a secret named
+`k2s-cluster-net-tls` which is configured to be created and updated by
+`cert-manager` - if the `security` addon is installed.
+If the security add-on is not installed, NGINX provides a default certificate.
+See also [Security Addon](../security/README.md).
+
+Web applications can use this host name in their ingress rules
+and do not need to care about TLS anymore, since it is handled by this
+central ingress. All rules using the same host will me merged by the ingress
+controller - so the only important thing is to have distinct Prefix rules.
+
+All Addons with a Web UI use this feature,
+and are configured to be reachable under two endpoints:
+
+- k2s-_nameOfAddOn_.local/
+- k2s.cluster.net/_nameOfAddOn_/
+
+Making web applications available under different paths is not trivial,
+and might even not be possible. In fact, it turns out that each of the Addons
+provided by K2s uses another mechanism to make this possible.
+The Ingress Resource definitions are worth being analyzed,
+to understand the different mechanisms:
+
+- Kubernetes Dashboard:
+  [NGINX Ingresses](../dashboard/manifests/dashboard-nginx-ingress.yaml).
+- Logging:
+  [NGINX Ingress](../logging/manifests/opensearch-dashboards/ingress.yaml).
+- Monitoring:
+  [NGINX Ingress](../monitoring/manifests/plutono/ingress.yaml).
 
 ## Further Reading
+
 - [Services, Load Balancing, and Networking](https://kubernetes.io/docs/concepts/services-networking/)
 - [NGINX Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/)

--- a/addons/ingress-nginx/README.md
+++ b/addons/ingress-nginx/README.md
@@ -18,7 +18,7 @@ it to pods running inside the platform.
 
 ## Getting started
 
-The ingress-nginx addon can be enabled using the k2s CLI
+The ingress-nginx addon can be enabled using the `k2s` CLI
 by running the following command:
 
 ```cmd
@@ -38,7 +38,7 @@ The ingress controller is configured so that it can be reached from outside
 the cluster via the external IP Address `172.19.1.100`.
 
 _Note:_ It is only possible to enable one ingress controller or gateway
-controller (ingress-nginx, traefik or gateway-nginx) in the k2s cluster at the
+controller (ingress-nginx, traefik or gateway-nginx) in the K2s cluster at the
 same time since they use the same ports.
 
 This Addon prepares one central TLS termination, matching the hostname

--- a/addons/ingress-nginx/manifests/cluster-net-ingress.yaml
+++ b/addons/ingress-nginx/manifests/cluster-net-ingress.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
+#
+# SPDX-License-Identifier: MIT
+
+# This Ingress serves as central ingress host for the cluster.
+# Any ingress, in any namespace, can use the same hostname, and it will be
+# merged with this one. See for example:
+#  addons/dashboard/manifests/dashboard-nginx-ingress.yaml
+#  addons/logging/manifests/opensearch-dashboards/ingress.yaml
+# The certificate is taken from k8s secret 'k2s-cluster-net-tls'
+# This secret will be created by cert-manager, if it is running.
+# If cert-manager is not running, the secret will not be present and nginx
+# will use an own self-signed certificate.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # addon security installs cert-manager, which will create the secret
+    # based on these annotations and the tls configuration below.
+    cert-manager.io/cluster-issuer: k2s-ca-issuer
+    cert-manager.io/common-name: k2s.cluster.net
+    # shall HTTP requests be re-directed to HTTPS? (default: true)
+    # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  name: nginx-cluster-net
+  namespace: ingress-nginx
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: k2s.cluster.net
+  tls:
+  - hosts:
+    - k2s.cluster.net
+    secretName: k2s-cluster-net-tls

--- a/addons/logging/Enable.ps1
+++ b/addons/logging/Enable.ps1
@@ -133,6 +133,9 @@ if (!$kubectlCmd.Success) {
 if (Test-TraefikIngressControllerAvailability) {
     (Invoke-Kubectl -Params 'apply', '-f', "$manifestsPath\opensearch-dashboards\traefik.yaml").Output | Write-Log
 }
+elseif (Test-NginxIngressControllerAvailability) {
+    (Invoke-Kubectl -Params 'apply', '-f', "$manifestsPath\opensearch-dashboards\ingress.yaml").Output | Write-Log
+}
 Add-HostEntries -Url 'k2s-logging.local'
 
 # Import saved objects 

--- a/addons/logging/logging.module.psm1
+++ b/addons/logging/logging.module.psm1
@@ -24,6 +24,18 @@ function Enable-IngressAddon([string]$Ingress) {
 
 <#
 .DESCRIPTION
+Determines if Nginx ingress controller is deployed in the cluster
+#>
+function Test-NginxIngressControllerAvailability {
+    $existingServices = (Invoke-Kubectl -Params 'get', 'service', '-n', 'ingress-nginx', '-o', 'yaml').Output 
+    if ("$existingServices" -match '.*ingress-nginx-controller.*') {
+        return $true
+    }
+    return $false
+}
+
+<#
+.DESCRIPTION
 Determines if Traefik ingress controller is deployed in the cluster
 #>
 function Test-TraefikIngressControllerAvailability {

--- a/addons/logging/manifests/opensearch-dashboards/deployment.yaml
+++ b/addons/logging/manifests/opensearch-dashboards/deployment.yaml
@@ -73,6 +73,10 @@ spec:
           value: "http://opensearch-cluster-master:9200"
         - name: SERVER_HOST
           value: "0.0.0.0"
+        - name: SERVER_BASEPATH
+          value: "/logging"
+        - name: SERVER_REWRITEBASEPATH
+          value: "false"
         - name: DISABLE_SECURITY_DASHBOARDS_PLUGIN
           value: "true"
         ports:

--- a/addons/logging/manifests/opensearch-dashboards/ingress.yaml
+++ b/addons/logging/manifests/opensearch-dashboards/ingress.yaml
@@ -2,12 +2,29 @@
 #
 # SPDX-License-Identifier: MIT
 
+# The opensearch-dashboards service exposes a web application on port 5601
+# It is uses a very tricky design to solve the problem of relative paths:
+# in the deployment.yaml, we configure these environment variables:
+# SERVER_BASEPATH = "/logging": the application will generate all relative
+#    URLs starting with this prefix!
+# SERVER_REWRITEBASEPATH = "false": the application will NOT expect the 
+# incoming calls to be part of the request path
+# This gives us the flexibility to expose the application on the configured
+# path, in this case "/logging"
 ---
 # Source: kube-prometheus-stack/charts/grafana/templates/ingress.yaml
+# Modified by us!
+# This ingress will expose the opensearch-dashboards web application on:
+# HTTP: http://k2s-logging.local
+# TLS: https://k2s-logging.local
+# For TLS, the certificate is taken from k8s secret 'k2s-logging-local-tls'
+# This secret will be created by cert-manager, if it is running.
+# If cert-manager is not running, the secret will not be present and nginx
+# will use an own self-signed certificate.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: opensearch-dashboards-ingress
+  name: logging-nginx-local
   namespace: logging
   labels:
     helm.sh/chart: opensearch-dashboards-2.16.0
@@ -15,8 +32,17 @@ metadata:
     app.kubernetes.io/instance: opensearch-dashboards
     app.kubernetes.io/version: "2.12.0"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    cert-manager.io/cluster-issuer: k2s-ca-issuer
+    cert-manager.io/common-name: k2s-logging.local
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: nginx
+  tls:
+  - hosts:
+    - k2s-logging.local
+    secretName: k2s-logging-local-tls
   rules:
     - host: k2s-logging.local
       http:
@@ -26,5 +52,35 @@ spec:
                 name: opensearch-dashboards
                 port:
                   number: 5601
-            path: /
+# this is tricky: when we call first time http://k2s-logging.local, 
+# the first parameter will not match and is ignored. The result will
+# contain relative paths starting with "/logging", when the client
+# calls them, the first parameter will be matched, but ignored.
+# In all cases, only the second parameters is forwarded to the backend
+            path: /(logging/)?(.*)
+            pathType: Prefix
+---
+# this ingress will be merged with ingress provided in:
+# addons/ingress-nginx/manifests/cluster-net-ingress.yaml
+# and exposes the opensearch-dashboards web application on:
+# https://k2s.cluster.net/logging/
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: logging-nginx-cluster-net
+  namespace: logging
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: "/$1"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: k2s.cluster.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: opensearch-dashboards
+                port:
+                  number: 5601
+            path: /logging/?(.*)
             pathType: Prefix

--- a/addons/logging/manifests/opensearch-dashboards/kustomization.yaml
+++ b/addons/logging/manifests/opensearch-dashboards/kustomization.yaml
@@ -10,4 +10,3 @@ resources:
 - serviceaccount.yaml
 - deployment.yaml
 - service.yaml
-- ingress.yaml

--- a/addons/logging/manifests/opensearch-dashboards/traefik.yaml
+++ b/addons/logging/manifests/opensearch-dashboards/traefik.yaml
@@ -2,21 +2,84 @@
 #
 # SPDX-License-Identifier: MIT
 
+# The opensearch-dashboards service exposes a web application on port 5601
+# It is uses a very tricky design to solve the problem of relative paths:
+# in the deployment.yaml, we configure these environment variables:
+# SERVER_BASEPATH = "/logging": the application will generate all relative
+#    URLs starting with this prefix!
+# SERVER_REWRITEBASEPATH = "false": the application will NOT expect the 
+# incoming calls to be part of the request path
+# This gives us the flexibility to expose the application on the configured
+# path, in this case "/logging"
 ---
+# This middleware trips the prefix "/logging" from the request, if present
+# is is used below in 
+# 'traefik.ingress.kubernetes.io/router.middlewares' annotation
 apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
+kind: Middleware
 metadata:
-  name: opensearch-dashboards-traefik
+  name: strip-prefix
+  namespace: logging
+spec:
+  stripPrefix:
+    prefixes:
+      - /logging
+---
+# This ingress will expose the opensearch-dashboards web application on:
+# HTTP: http://k2s-logging.local
+# TLS: https://k2s-logging.local
+# For TLS, the certificate is taken from k8s secret 'k2s-logging-local-tls'
+# This secret will be created by cert-manager, if it is running.
+# If cert-manager is not running, the secret will not be present and traefik
+# will use an own self-signed certificate.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: logging-traefik-local
   namespace: logging
   annotations:
-    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: k2s-ca-issuer
+    cert-manager.io/common-name: k2s-logging.local
+    traefik.ingress.kubernetes.io/router.middlewares: logging-strip-prefix@kubernetescrd
 spec:
-  entryPoints:
-    - web
-  routes:
-    - match: Host(`k2s-logging.local`) && PathPrefix(`/`)
-      kind: Rule
-      services:
-        - name: opensearch-dashboards
-          namespace: logging
-          port: 5601
+  ingressClassName: traefik
+  tls:
+  - hosts:
+    - k2s-logging.local
+    secretName: k2s-logging-local-tls
+  rules:
+    - host: k2s-logging.local
+      http:
+        paths:
+        - backend:
+            service:
+              name: opensearch-dashboards
+              port: 
+                number: 5601
+          pathType: Prefix
+          path: /
+---
+# this ingress will be merged with ingress provided in:
+# addons/traefik/manifests/cluster-net-ingress.yaml
+# and exposes the opensearch-dashboards angular application on:
+# https://k2s.cluster.net/logging/
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: logging-traefik-cluster-net
+  namespace: logging
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: logging-strip-prefix@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: k2s.cluster.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: opensearch-dashboards
+                port:
+                  number: 5601
+            path: /logging
+            pathType: Prefix

--- a/addons/monitoring/Enable.ps1
+++ b/addons/monitoring/Enable.ps1
@@ -113,6 +113,9 @@ if (!$kubectlCmd.Success) {
 if (Test-TraefikIngressControllerAvailability) {
     (Invoke-Kubectl -Params 'apply', '-f', "$manifestsPath\plutono\traefik.yaml").Output | Write-Log
 }
+elseif (Test-NginxIngressControllerAvailability) {
+    (Invoke-Kubectl -Params 'apply', '-f', "$manifestsPath\plutono\ingress.yaml").Output | Write-Log
+}
 
 Add-HostEntries -Url 'k2s-monitoring.local'
 

--- a/addons/monitoring/manifests/plutono/configmap.yaml
+++ b/addons/monitoring/manifests/plutono/configmap.yaml
@@ -30,7 +30,7 @@ data:
     provisioning = /etc/plutono/provisioning
     [server]
     # these settings needed to make it work with Ingress
-    root_url = https://k2s-monitoring.local/monitoring
+    root_url = https://k2s.cluster.net/monitoring
     domain = k2s.cluster.net
     protocol = https
     cert_key = /cert/tls.key

--- a/addons/monitoring/manifests/plutono/configmap.yaml
+++ b/addons/monitoring/manifests/plutono/configmap.yaml
@@ -30,8 +30,8 @@ data:
     provisioning = /etc/plutono/provisioning
     [server]
     # these settings needed to make it work with Ingress
-    root_url = https://k2s-monitoring.local
-    domain = k2s-monitoring.local
+    root_url = https://k2s-monitoring.local/monitoring
+    domain = k2s.cluster.net
     protocol = https
     cert_key = /cert/tls.key
     cert_file = /cert/tls.crt

--- a/addons/monitoring/manifests/plutono/ingress.yaml
+++ b/addons/monitoring/manifests/plutono/ingress.yaml
@@ -2,12 +2,25 @@
 #
 # SPDX-License-Identifier: MIT
 
+# This web application can be configured to re-encode its relative URLs
+# with a configurable prefix, see file `configmap.yaml`:
+# root_url = https://k2s-monitoring.local/monitoring
+# This enables us to expose it trough the ingress under this configured path
 ---
 # Source: kube-prometheus-stack/charts/grafana/templates/ingress.yaml
+# Modified by us!
+#
+# This ingress will expose the plutono web application on:
+# HTTP: http://k2s-monitoring.local
+# TLS: https://k2s-monitoring.local
+# For TLS, the certificate is taken from k8s secret 'k2s-monitoring-local-tls'
+# This secret will be created by cert-manager, if it is running.
+# If cert-manager is not running, the secret will not be present and nginx
+# will use an own self-signed certificate.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: kube-prometheus-stack-plutono
+  name: monitoring-nginx-local
   namespace: monitoring
   labels:
     helm.sh/chart: grafana-6.57.4
@@ -16,13 +29,17 @@ metadata:
     app.kubernetes.io/version: "9.5.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
+    cert-manager.io/cluster-issuer: k2s-ca-issuer
+    cert-manager.io/common-name: k2s-monitoring.local
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: nginx
   tls:
   - hosts:
       - k2s-monitoring.local
-    secretName: certs-secret-plutono
+    secretName: k2s-monitoring-local-tls
   rules:
     - host: k2s-monitoring.local
       http:
@@ -32,5 +49,34 @@ spec:
                 name: kube-prometheus-stack-plutono
                 port:
                   number: 443
-            path: /
+# this is tricky: the optional match (monitoring/)? will allow us to make
+# the first call to /. After that, all relative paths start with /monitoring
+# as configured in the configmap.yaml, and will also match the path:
+            path: /(monitoring/)?(.*)
+            pathType: Prefix
+---
+# This ingress will be merged with ingress provided in:
+# addons/ingress-nginx/manifests/cluster-net-ingress.yaml
+# and exposes the plutono web application on:
+# https://k2s.cluster.net/monitoring/
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: monitoring-nginx-cluster-net
+  namespace: monitoring
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/rewrite-target: "/$1"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: k2s.cluster.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: kube-prometheus-stack-plutono
+                port:
+                  number: 443
+            path: /monitoring/?(.*)
             pathType: Prefix

--- a/addons/monitoring/manifests/plutono/kustomization.yaml
+++ b/addons/monitoring/manifests/plutono/kustomization.yaml
@@ -14,7 +14,6 @@ resources:
 - configmap.yaml
 - configmaps-datasources.yaml
 - deployment.yaml
-- ingress.yaml
 - role.yaml
 - rolebinding.yaml
 - secret.yaml

--- a/addons/monitoring/manifests/plutono/traefik.yaml
+++ b/addons/monitoring/manifests/plutono/traefik.yaml
@@ -2,23 +2,81 @@
 #
 # SPDX-License-Identifier: MIT
 
+# This web application can be configured to re-encode its relative URLs
+# with a configurable prefix, see file `configmap.yaml`:
+# root_url = https://k2s-monitoring.local/monitoring
+# This enables us to expose it trough the ingress under this configured path
 ---
+# This middleware strips the prefix "/monitoring" from the request, if present
+# is is used below in 
+# 'traefik.ingress.kubernetes.io/router.middlewares' annotation
 apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
+kind: Middleware
 metadata:
-  name: plutono-ingressroute
+  name: strip-prefix
+  namespace: monitoring
+spec:
+  stripPrefix:
+    prefixes:
+      - /monitoring
+---
+# This ingress will expose the plutono web application on:
+# HTTP: http://k2s-monitoring.local
+# TLS: https://k2s-monitoring.local
+# For TLS, the certificate is taken from k8s secret 'k2s-monitoring-local-tls'
+# This secret will be created by cert-manager, if it is running.
+# If cert-manager is not running, the secret will not be present and traefik
+# will use an own self-signed certificate.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: monitoring-traefik-local
   namespace: monitoring
   annotations:
-    kubernetes.io/ingress.class: traefik
+    cert-manager.io/cluster-issuer: k2s-ca-issuer
+    cert-manager.io/common-name: k2s-monitoring.local
+    traefik.ingress.kubernetes.io/router.middlewares: monitoring-strip-prefix@kubernetescrd
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
-  entryPoints:
-    - websecure
-  routes:
-    - match: Host(`k2s-monitoring.local`) && PathPrefix(`/`)
-      kind: Rule
-      services:
-        - name: kube-prometheus-stack-plutono
-          namespace: monitoring
-          port: 443
+  ingressClassName: traefik
   tls:
-    secretName: certs-secret-plutono
+  - hosts:
+      - k2s-monitoring.local
+    secretName: k2s-monitoring-local-tls
+  rules:
+    - host: k2s-monitoring.local
+      http:
+        paths:
+          - backend:
+              service:
+                name: kube-prometheus-stack-plutono
+                port:
+                  number: 443
+            path: /
+            pathType: Prefix
+---
+# this ingress will be merged with ingress provided in:
+# addons/traefik/manifests/cluster-net-ingress.yaml
+# and exposes the plutono web application on:
+# https://k2s.cluster.net/monitoring/
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: monitoring-traefik-cluster-net
+  namespace: monitoring
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: monitoring-strip-prefix@kubernetescrd
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: k2s.cluster.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: kube-prometheus-stack-plutono
+                port:
+                  number: 443
+            path: /monitoring
+            pathType: Prefix

--- a/addons/monitoring/monitoring.module.psm1
+++ b/addons/monitoring/monitoring.module.psm1
@@ -63,3 +63,15 @@ function Test-TraefikIngressControllerAvailability {
     }
     return $false
 }
+
+<#
+.DESCRIPTION
+Determines if Nginx ingress controller is deployed in the cluster
+#>
+function Test-NginxIngressControllerAvailability {
+    $existingServices = (Invoke-Kubectl -Params 'get', 'service', '-n', 'ingress-nginx', '-o', 'yaml').Output 
+    if ("$existingServices" -match '.*ingress-nginx-controller.*') {
+        return $true
+    }
+    return $false
+}

--- a/addons/security/Disable.ps1
+++ b/addons/security/Disable.ps1
@@ -29,6 +29,7 @@ $addonsModule = "$PSScriptRoot\..\addons.module.psm1"
 $securityModule = "$PSScriptRoot\security.module.psm1"
 
 Import-Module $infraModule, $clusterModule, $addonsModule, $securityModule
+Import-Module PKI;
 
 Initialize-Logging -ShowLogs:$ShowLogs
 

--- a/addons/security/Disable.ps1
+++ b/addons/security/Disable.ps1
@@ -68,6 +68,8 @@ $caIssuerConfig = Get-CAIssuerConfig
 Remove-Cmctl
 Remove-AddonFromSetupJson -Name 'security'
 
+(Get-ChildItem Cert:\LocalMachine\Root | Where-Object { $_.Subject -match 'K2s Self-Signed CA' } | Remove-Item).Output | Write-Log
+
 Write-Log 'Uninstallation of security finished' -Console
 
 Write-WarningForUser

--- a/addons/security/Disable.ps1
+++ b/addons/security/Disable.ps1
@@ -66,10 +66,13 @@ $caIssuerConfig = Get-CAIssuerConfig
 (Invoke-Kubectl -Params 'delete', '-f', $certManagerConfig).Output | Write-Log
 
 Remove-Cmctl
+
+Write-Log 'Removing CA issuer certificate from trusted root' -Console
+$caIssuerName = Get-CAIssuerName
+$trustedRootStoreLocation = Get-TrustedRootStoreLocation
+Get-ChildItem -Path $trustedRootStoreLocation | Where-Object { $_.Subject -match $caIssuerName } | Remove-Item
+
 Remove-AddonFromSetupJson -Name 'security'
-
-(Get-ChildItem Cert:\LocalMachine\Root | Where-Object { $_.Subject -match 'K2s Self-Signed CA' } | Remove-Item).Output | Write-Log
-
 Write-Log 'Uninstallation of security finished' -Console
 
 Write-WarningForUser

--- a/addons/security/Enable.ps1
+++ b/addons/security/Enable.ps1
@@ -37,6 +37,7 @@ $addonsModule = "$PSScriptRoot\..\addons.module.psm1"
 $securityModule = "$PSScriptRoot\security.module.psm1"
 
 Import-Module $infraModule, $clusterModule, $nodeModule, $addonsModule, $securityModule
+Import-Module PKI;
 
 Initialize-Logging -ShowLogs:$ShowLogs
 

--- a/addons/security/Enable.ps1
+++ b/addons/security/Enable.ps1
@@ -128,7 +128,11 @@ Write-Log 'Importing CA root certificate to trusted authorities of your computer
 $b64secret = (Invoke-Kubectl -Params '-n', 'cert-manager', 'get', 'secrets', 'ca-issuer-root-secret', '-o', 'jsonpath', '--template', '{.data.ca\.crt}').Output
 $tempFile = New-TemporaryFile
 [Text.Encoding]::Utf8.GetString([Convert]::FromBase64String($b64secret)) | Out-File -Encoding utf8 -FilePath $tempFile.FullName -Force
-certutil -addstore -f -enterprise -user root $tempFile.FullName
+$params = @{
+    FilePath          = $tempFile.FullName
+    CertStoreLocation = 'Cert:\LocalMachine\Root'
+}
+(Import-Certificate @params).Output | Write-Log
 Remove-Item -Path $tempFile.FullName -Force
 
 Add-AddonToSetupJson -Addon ([pscustomobject] @{Name = 'security' })

--- a/addons/security/Enable.ps1
+++ b/addons/security/Enable.ps1
@@ -127,12 +127,14 @@ if ($caCreated -ne $true) {
 Write-Log 'Importing CA root certificate to trusted authorities of your computer' -Console
 $b64secret = (Invoke-Kubectl -Params '-n', 'cert-manager', 'get', 'secrets', 'ca-issuer-root-secret', '-o', 'jsonpath', '--template', '{.data.ca\.crt}').Output
 $tempFile = New-TemporaryFile
+$certLocationStore = Get-TrustedRootStoreLocation
 [Text.Encoding]::Utf8.GetString([Convert]::FromBase64String($b64secret)) | Out-File -Encoding utf8 -FilePath $tempFile.FullName -Force
 $params = @{
     FilePath          = $tempFile.FullName
-    CertStoreLocation = 'Cert:\LocalMachine\Root'
+    CertStoreLocation = $certLocationStore
 }
-(Import-Certificate @params).Output | Write-Log
+
+Import-Certificate @params
 Remove-Item -Path $tempFile.FullName -Force
 
 Add-AddonToSetupJson -Addon ([pscustomobject] @{Name = 'security' })

--- a/addons/security/security.module.psm1
+++ b/addons/security/security.module.psm1
@@ -11,6 +11,14 @@ Import-Module $infraModule, $k8sApiModule
 
 $cmctlExe = "$(Get-KubeToolsPath)\cmctl.exe"
 
+function Get-CAIssuerName {
+    return 'K2s Self-Signed CA'
+}
+
+function Get-TrustedRootStoreLocation {
+    return 'Cert:\LocalMachine\Root'
+}
+
 function Get-CertManagerConfig {
     return "$PSScriptRoot\manifests\cert-manager.yaml"
 }

--- a/addons/traefik/Enable.ps1
+++ b/addons/traefik/Enable.ps1
@@ -121,6 +121,9 @@ if ($allPodsAreUp -ne $true) {
 
 Write-Log 'All traefik pods are up and ready.' -Console
 
+$clusterIngressConfig = "$PSScriptRoot\manifests\cluster-net-ingress.yaml"
+(Invoke-Kubectl -Params 'apply' , '-f', $clusterIngressConfig).Output | Write-Log
+
 Add-AddonToSetupJson -Addon ([pscustomobject] @{Name = 'traefik' })
 
 Write-Log 'Installation of Traefik addon finished.' -Console

--- a/addons/traefik/README.md
+++ b/addons/traefik/README.md
@@ -8,20 +8,62 @@ SPDX-License-Identifier: MIT
 
 ## Introduction
 
-The `traefik` addon provides an implementation of the [Traefik](https://github.com/traefik/traefik) Ingress Controller. Traefik is a modern HTTP reverse proxy and load balancer that makes deploying and accessing microservices easy.
+The `traefik` addon provides an implementation of the Ingress Controller with
+[ingressClassName: traefik](https://github.com/traefik/traefik).
+Traefik is a modern HTTP reverse proxy and load balancer that makes
+deploying and accessing microservices easy.
 
 ## Getting started
 
 The traefik addon can be enabled using the k2s CLI by running the following command:
-```
+
+```cmd
 k2s addons enable traefik
 ```
+
 ## Creating ingress routes
 
-Unlike the NGINX Ingress Controller, Traefik uses Custom Resource Definitions for defining ingress routes. How to create an ingress route can be found [here](https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/).
+In addition to implementing the Kubernetes `Ingress` Interface,
+Traefik uses Custom Resource Definitions (CRD) to define several other
+resource kinds like e.g. `IngressRoute` - see
+[documentation](https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/).
 
 ## Access of the ingress controller
 
-The ingress controller is configured so that it can be reached from outside the cluster via the external IP Address `172.19.1.100`.
+The ingress controller is configured so that it can be reached from outside
+the cluster via the external IP Address `172.19.1.100`.
 
-_Note:_ It is only possible to enable one ingress controller or gateway controller (ingress-nginx, traefik or gateway-nginx) in the k2s cluster at the same time since they use the same ports.
+_Note:_ It is only possible to enable one ingress controller or gateway
+controller (ingress-nginx, traefik or gateway-nginx) in the k2s cluster at the
+same time since they use the same ports.
+
+This Addon prepares one central TLS termination, matching the hostname
+`k2s.cluster.net`, and using as certificate a secret named
+`k2s-cluster-net-tls` which is configured to be created and updated by
+`cert-manager` - if the `security` addon is installed.
+If the security add-on is not installed, NGINX provides a default certificate.
+See also [Security Addon](../security/README.md).
+
+Web applications can use this host name in their ingress rules
+and do not need to care about TLS anymore, since it is handled by this
+central ingress. All rules using the same host will me merged by the ingress
+controller - so the only important thing is to have distinct Prefix rules.
+
+All Addons with a Web UI use this feature,
+and are configured to be reachable under two endpoints:
+
+- k2s-_nameOfAddOn_.local/
+- k2s.cluster.net/_nameOfAddOn_/
+
+Making web applications available under different paths is not trivial,
+and might even not be possible. In fact, it turns out that each of the Addons
+provided by K2s uses another mechanism to make this possible.
+The Ingress Resource definitions are worth being analyzed,
+to understand the different mechanisms:
+
+- Kubernetes Dashboard:
+  [Traefik Ingress](../dashboard/manifests/dashboard-traefik-ingress.yaml).
+- Logging:
+  [Traefik Ingress](../logging/manifests/opensearch-dashboards/traefik.yaml).
+- Monitoring:
+  [Traefik Ingress](../monitoring/manifests/plutono/traefik.yaml).

--- a/addons/traefik/README.md
+++ b/addons/traefik/README.md
@@ -15,7 +15,7 @@ deploying and accessing microservices easy.
 
 ## Getting started
 
-The traefik addon can be enabled using the k2s CLI by running the following command:
+The traefik addon can be enabled using the `k2s` CLI by running the following command:
 
 ```cmd
 k2s addons enable traefik
@@ -34,7 +34,7 @@ The ingress controller is configured so that it can be reached from outside
 the cluster via the external IP Address `172.19.1.100`.
 
 _Note:_ It is only possible to enable one ingress controller or gateway
-controller (ingress-nginx, traefik or gateway-nginx) in the k2s cluster at the
+controller (ingress-nginx, traefik or gateway-nginx) in the K2s cluster at the
 same time since they use the same ports.
 
 This Addon prepares one central TLS termination, matching the hostname

--- a/addons/traefik/manifests/cluster-net-ingress.yaml
+++ b/addons/traefik/manifests/cluster-net-ingress.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
+#
+# SPDX-License-Identifier: MIT
+
+# This Ingress serves as central ingress host for the cluster.
+# Any ingress, in any namespace, can use the same hostname, and it will be
+# merged with this one. See for example:
+#  addons/dashboard/manifests/dashboard-traefik-ingress.yaml
+#  addons/logging/manifests/opensearch-dashboards/traefik.yaml
+# The certificate is taken from k8s secret 'k2s-cluster-net-tls'
+# This secret will be created by cert-manager, if it is running.
+# If cert-manager is not running, the secret will not be present and traefik
+# will use an own self-signed certificate.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # addon security installs cert-manager, which will create the secret
+    # based on these annotations and the tls configuration below.
+    cert-manager.io/cluster-issuer: k2s-ca-issuer
+    cert-manager.io/common-name: k2s.cluster.net
+  name: traefik-cluster-net
+  namespace: traefik
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: k2s.cluster.net
+  tls:
+  - hosts:
+    - k2s.cluster.net
+    secretName: k2s-cluster-net-tls

--- a/k2s/test/e2e/addons/dashboard/dashboard_test.go
+++ b/k2s/test/e2e/addons/dashboard/dashboard_test.go
@@ -32,7 +32,7 @@ var (
 
 func TestDashboard(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "dasboard Addon Acceptance Tests", Label("addon", "acceptance", "setup-required", "invasive", "dashboard", "system-running"))
+	RunSpecs(t, "dashboard Addon Acceptance Tests", Label("addon", "acceptance", "setup-required", "invasive", "dashboard", "system-running"))
 }
 
 var _ = BeforeSuite(func(ctx context.Context) {
@@ -160,8 +160,14 @@ var _ = Describe("'dashboard' addon", Ordered, func() {
 				Expect(addonsStatus.IsAddonEnabled("dashboard")).To(BeTrue())
 			})
 
-			It("is reachable through traefik", func(ctx context.Context) {
+			It("is reachable through k2s-dashboard.local", func(ctx context.Context) {
 				url := "https://k2s-dashboard.local/#/pod?namespace=_all"
+				httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
+				Expect(httpStatus).To(ContainSubstring("200"))
+			})
+
+			It("is reachable through k2s.cluster.net", func(ctx context.Context) {
+				url := "https://k2s.cluster.net/dashboard/#/pod?namespace=_all"
 				httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
 				Expect(httpStatus).To(ContainSubstring("200"))
 			})
@@ -207,9 +213,15 @@ var _ = Describe("'dashboard' addon", Ordered, func() {
 				Expect(addonsStatus.IsAddonEnabled("dashboard")).To(BeTrue())
 			})
 
-			It("is reachable through ingress-nginx", func(ctx context.Context) {
+			It("is reachable through k2s-dashboard.local", func(ctx context.Context) {
 				url := "https://k2s-dashboard.local/#/pod?namespace=_all"
 				httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "10", "--fail")
+				Expect(httpStatus).To(ContainSubstring("200"))
+			})
+
+			It("is reachable through k2s.cluster.net", func(ctx context.Context) {
+				url := "https://k2s.cluster.net/dashboard/#/pod?namespace=_all"
+				httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
 				Expect(httpStatus).To(ContainSubstring("200"))
 			})
 

--- a/k2s/test/e2e/addons/ingress-nginx/ingress-nginx_test.go
+++ b/k2s/test/e2e/addons/ingress-nginx/ingress-nginx_test.go
@@ -75,6 +75,12 @@ var _ = Describe("'ingress-nginx' addon", Ordered, func() {
 		Expect(output).To(ContainSubstring("already enabled"))
 	})
 
+	It("makes k2s.cluster.net reachable, with http status NotFound", func(ctx context.Context) {
+		url := "https://k2s.cluster.net/"
+		httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3")
+		Expect(httpStatus).To(ContainSubstring("404"))
+	})
+
 	It("sample app is reachable through ingress-nginx ingress controller", func(ctx context.Context) {
 		suite.Kubectl().Run(ctx, "apply", "-k", "workloads")
 		suite.Cluster().ExpectPodsUnderDeploymentReady(ctx, "app", "albums-linux1", "ingress-nginx-test")

--- a/k2s/test/e2e/addons/logging/logging_test.go
+++ b/k2s/test/e2e/addons/logging/logging_test.go
@@ -186,10 +186,20 @@ var _ = Describe("'logging' addon", Ordered, func() {
 			expectStatusToBePrinted(ctx)
 		})
 
-		It("is reachable through traefik", func(ctx context.Context) {
+		It("is reachable through k2s-logging.local", func(ctx context.Context) {
 			url := "http://k2s-logging.local"
 			httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
+			// we expect a re-direct to /logging/app/home
 			Expect(httpStatus).To(ContainSubstring("302"))
+			Expect(httpStatus).To(ContainSubstring("/logging/app/home"))
+		})
+
+		It("is reachable through k2s.cluster.net/logging", func(ctx context.Context) {
+			url := "https://k2s.cluster.net/logging"
+			httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
+			// we expect a re-direct to /logging/app/home
+			Expect(httpStatus).To(ContainSubstring("302"))
+			Expect(httpStatus).To(ContainSubstring("/logging/app/home"))
 		})
 	})
 
@@ -244,10 +254,20 @@ var _ = Describe("'logging' addon", Ordered, func() {
 			expectStatusToBePrinted(ctx)
 		})
 
-		It("is reachable through ingress-nginx", func(ctx context.Context) {
+		It("is reachable through k2s-logging.local/", func(ctx context.Context) {
 			url := "http://k2s-logging.local"
 			httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "10", "--fail")
+			// we expect a re-direct to /logging/app/home
 			Expect(httpStatus).To(ContainSubstring("302"))
+			Expect(httpStatus).To(ContainSubstring("/logging/app/home"))
+		})
+
+		It("is reachable through k2s.cluster.net/logging/", func(ctx context.Context) {
+			url := "https://k2s.cluster.net/logging"
+			httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
+			// we expect a re-direct to /logging/app/home
+			Expect(httpStatus).To(ContainSubstring("302"))
+			Expect(httpStatus).To(ContainSubstring("/logging/app/home"))
 		})
 	})
 })

--- a/k2s/test/e2e/addons/monitoring/monitoring_test.go
+++ b/k2s/test/e2e/addons/monitoring/monitoring_test.go
@@ -144,8 +144,14 @@ var _ = Describe("'monitoring' addon", Ordered, func() {
 			expectStatusToBePrinted(ctx)
 		})
 
-		It("is reachable through traefik", func(ctx context.Context) {
+		It("is reachable through k2s-monitoring.local", func(ctx context.Context) {
 			url := "https://k2s-monitoring.local/login"
+			httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
+			Expect(httpStatus).To(ContainSubstring("200"))
+		})
+
+		It("is reachable through k2s.cluster.net/monitoring", func(ctx context.Context) {
+			url := "https://k2s.cluster.net/monitoring/login"
 			httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
 			Expect(httpStatus).To(ContainSubstring("200"))
 		})
@@ -196,9 +202,15 @@ var _ = Describe("'monitoring' addon", Ordered, func() {
 			expectStatusToBePrinted(ctx)
 		})
 
-		It("is reachable through ingress-nginx", func(ctx context.Context) {
+		It("is reachable through k2s-monitoring.local", func(ctx context.Context) {
 			url := "https://k2s-monitoring.local/login"
 			httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "10", "--fail")
+			Expect(httpStatus).To(ContainSubstring("200"))
+		})
+
+		It("is reachable through k2s.cluster.net/monitoring", func(ctx context.Context) {
+			url := "https://k2s.cluster.net/monitoring/login"
+			httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
 			Expect(httpStatus).To(ContainSubstring("200"))
 		})
 	})

--- a/k2s/test/e2e/addons/security/security_test.go
+++ b/k2s/test/e2e/addons/security/security_test.go
@@ -7,6 +7,8 @@ package security
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/addons/status"
@@ -110,7 +112,29 @@ var _ = Describe("'security' addon", Ordered, func() {
 			)))
 	})
 
+	It("installs cmctl.exe, the cert-manager CLI", func(ctx context.Context) {
+		cmCtlPath := path.Join(suite.RootDir(), "bin", "exe", "cmctl.exe")
+		_, err := os.Stat(cmCtlPath)
+		Expect(err).To(BeNil())
+	})
+
+	It("creates the ca-issuer-root-secret", func(ctx context.Context) {
+		output := suite.Kubectl().Run(ctx, "get", "secrets", "-n", "cert-manager", "ca-issuer-root-secret")
+		Expect(output).To(ContainSubstring("ca-issuer-root-secret"))
+	})
+
 	It("disables the addon", func(ctx context.Context) {
 		suite.K2sCli().Run(ctx, "addons", "disable", addonName, "-o")
+	})
+
+	It("uninstalls cmctl.exe, the cert-manager CLI", func(ctx context.Context) {
+		cmCtlPath := path.Join(suite.RootDir(), "bin", "exe", "cmctl.exe")
+		_, err := os.Stat(cmCtlPath)
+		Expect(err).NotTo(BeNil())
+	})
+
+	It("removed the ca-issuer-root-secret", func(ctx context.Context) {
+		output := suite.Kubectl().Run(ctx, "get", "secrets", "-A")
+		Expect(output).NotTo(ContainSubstring("ca-issuer-root-secret"))
 	})
 })

--- a/k2s/test/e2e/addons/security/security_test.go
+++ b/k2s/test/e2e/addons/security/security_test.go
@@ -130,7 +130,7 @@ var _ = Describe("'security' addon", Ordered, func() {
 	It("uninstalls cmctl.exe, the cert-manager CLI", func(ctx context.Context) {
 		cmCtlPath := path.Join(suite.RootDir(), "bin", "exe", "cmctl.exe")
 		_, err := os.Stat(cmCtlPath)
-		Expect(err).NotTo(BeNil())
+		Expect(os.IsNotExist(err)).To(BeTrue())
 	})
 
 	It("removed the ca-issuer-root-secret", func(ctx context.Context) {

--- a/k2s/test/e2e/addons/traefik/traefik_test.go
+++ b/k2s/test/e2e/addons/traefik/traefik_test.go
@@ -104,6 +104,12 @@ var _ = Describe("'traefik' addon", Ordered, func() {
 		Expect(output).To(ContainSubstring("already enabled"))
 	})
 
+	It("makes k2s.cluster.net reachable, with http status NotFound", func(ctx context.Context) {
+		url := "https://k2s.cluster.net/"
+		httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3")
+		Expect(httpStatus).To(ContainSubstring("404"))
+	})
+
 	It("sample app is reachable through traefik ingress controller", func(ctx context.Context) {
 		suite.Kubectl().Run(ctx, "apply", "-k", "workloads")
 		suite.Cluster().ExpectPodsUnderDeploymentReady(ctx, "app", "albums-linux1", "traefik-test")


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

### Motivation
This is part of the feature **#258: New addon security for the K2s cluster** and is addressing the TLS termination at Ingress (both: NGINX and Traefik)

This PR makes it possible for more web applications hosted on K2s to shall share one common ingress host, and expose their functionality under relative paths: `k2s.cluster.net`

Both `ingress-nginx` and `traefik` addons come now with a central TLS Ingress with no paths, but with a tls entry matching the mentioned hostname.

All Web UIs of our AddOns contain now a second ingress route, which is merged with the central one, so that each UI is now available under 3 URLs:
- Dashboard:  
  http://k2s-dashboard.local
  https://k2s-dashboard.local
  **new:** https://k2s.cluster.net/dashboard/
- Logging:
  http://k2s-logging.local
  https://k2s-logging.local
  **new:** https://k2s.cluster.net/logging/
- Monitoring:
  http://k2s-monitoring.local
  https://k2s-monitoring.local
  **new:** https://k2s.cluster.net/monitoring/

All TLS endpoints are secured with a certificate generated by **cert-manager**, which is installed with the **security** addon. The configuration files and scripts of all other addons are desined in such a way that they work regardless of the installation status of the **security** addon.

Security can be enabled at the end, at beginning or in between. As soon as it is enabled, secure Certificates will be used for all TLS-terminated ingresses.

### Modifications
These addons and their e2e tests where updated:
- dashboard
- logging
- monitoring
- ingress-nginx
- traefik
- security

### Verification
`k2s/test/e2e` tests are adapted / extended for addons mentioned above

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->