### PR TITLE
disable dns registration for loopback

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/network/network.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/network/network.module.psm1
@@ -31,7 +31,7 @@ function Add-DnsServer($switchname) {
     # add DNS proxy for cluster searches
     $ipindex = Get-NetIPInterface | ? InterfaceAlias -Like "*$switchname*" | ? AddressFamily -Eq IPv4 | select -expand 'ifIndex'
     Set-DnsClientServerAddress -InterfaceIndex $ipindex -ServerAddresses $ipControlPlane | Out-Null
-    Set-DnsClient -InterfaceIndex $ipindex -ConnectionSpecificSuffix 'cluster.local' | Out-Null
+    Set-DnsClient -InterfaceIndex $ipindex -ConnectionSpecificSuffix 'cluster.local' -RegisterThisConnectionsAddress $false | Out-Null
 }
 
 <#

--- a/lib/scripts/multivm/start/Start.ps1
+++ b/lib/scripts/multivm/start/Start.ps1
@@ -276,6 +276,7 @@ Invoke-Command -Session $session {
     $ipAddressForLoopbackAdapter = Get-LoopbackAdapterIP
     $ipGatewayLoopbackAdapter = Get-LoopbackAdapterGateway
     Set-IPAdressAndDnsClientServerAddress -IPAddress $ipAddressForLoopbackAdapter -DefaultGateway $ipGatewayLoopbackAdapter -Index $ipindexEthernet
+    Set-DnsClient -InterfaceIndex $ipindexEthernet -RegisterThisConnectionsAddress $false | Out-Null
     netsh int ipv4 set int "vEthernet ($adapterName)" forwarding=enabled | Out-Null
     netsh int ipv4 set int 'Ethernet' forwarding=enabled | Out-Null
 

--- a/smallsetup/StartK8s.ps1
+++ b/smallsetup/StartK8s.ps1
@@ -93,6 +93,7 @@ function UpdateIpAddress {
             $dnservers = Get-DnsClientServerAddress -InterfaceIndex $physicalInterfaceIndex -AddressFamily IPv4
             Write-Log "           DNSServers found in Physical Adapter ($physicalInterfaceIndex) : $($dnservers.ServerAddresses)"
             Set-IPAdressAndDnsClientServerAddress -IPAddress $ipaddress -DefaultGateway $gateway -Index $ipindex -DnsAddresses $dnservers.ServerAddresses
+            Set-DnsClient -InterfaceIndex $ipindex -RegisterThisConnectionsAddress $false | Out-Null
             $script:fixedIpWasSet = $true
         }
         else {

--- a/smallsetup/common/GlobalFunctions.ps1
+++ b/smallsetup/common/GlobalFunctions.ps1
@@ -1564,7 +1564,7 @@ function Add-DnsServer($switchname) {
     # add DNS proxy for cluster searches
     $ipindex = Get-NetIPInterface | ? InterfaceAlias -Like "*$switchname*" | ? AddressFamily -Eq IPv4 | select -expand 'ifIndex'
     Set-DnsClientServerAddress -InterfaceIndex $ipindex -ServerAddresses $global:IP_Master | Out-Null
-    Set-DnsClient -InterfaceIndex $ipindex -ConnectionSpecificSuffix 'cluster.local' | Out-Null
+    Set-DnsClient -InterfaceIndex $ipindex -ConnectionSpecificSuffix 'cluster.local' -RegisterThisConnectionsAddress $false | Out-Null
 }
 
 function Reset-DnsServer($switchname) {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #466

### Motivation

See Issue #466 

### Modifications

Disables the "Register this Connections IP Address on the DNS" when enabling the loopback adapter.

### Verification

To do...

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->