### PR TITLE
add retry-all-errors in curl command for dashboard tests

### DIFF
--- a/k2s/test/e2e/addons/dashboard/dashboard_test.go
+++ b/k2s/test/e2e/addons/dashboard/dashboard_test.go
@@ -215,13 +215,13 @@ var _ = Describe("'dashboard' addon", Ordered, func() {
 
 			It("is reachable through k2s-dashboard.local", func(ctx context.Context) {
 				url := "https://k2s-dashboard.local/#/pod?namespace=_all"
-				httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "10", "--fail")
+				httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "10", "--fail", "--retry-all-errors")
 				Expect(httpStatus).To(ContainSubstring("200"))
 			})
 
 			It("is reachable through k2s.cluster.net", func(ctx context.Context) {
 				url := "https://k2s.cluster.net/dashboard/#/pod?namespace=_all"
-				httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "3", "--fail")
+				httpStatus := suite.Cli().ExecOrFail(ctx, "curl.exe", url, "-k", "-I", "-m", "5", "--retry", "10", "--fail", "--retry-all-errors")
 				Expect(httpStatus).To(ContainSubstring("200"))
 			})
 


### PR DESCRIPTION
add retry-all-errors in curl command for dashboard tests