### PR TITLE
#457 fix(multivm image CMDs): erroneous commands disabled

### DIFF
--- a/k2s/cmd/k2s/cmd/image/build.go
+++ b/k2s/cmd/k2s/cmd/image/build.go
@@ -142,6 +142,10 @@ func buildImage(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err

--- a/k2s/cmd/k2s/cmd/image/clean.go
+++ b/k2s/cmd/k2s/cmd/image/clean.go
@@ -58,6 +58,10 @@ func cleanImages(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err

--- a/k2s/cmd/k2s/cmd/image/export.go
+++ b/k2s/cmd/k2s/cmd/image/export.go
@@ -66,6 +66,10 @@ func exportImage(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err

--- a/k2s/cmd/k2s/cmd/image/import.go
+++ b/k2s/cmd/k2s/cmd/image/import.go
@@ -61,7 +61,12 @@ func init() {
 }
 
 func importImage(cmd *cobra.Command, args []string) error {
-	psCmd, params, err := buildImportPsCmd(cmd)
+	isWindowsImage, err := strconv.ParseBool(cmd.Flags().Lookup(windowsFlag).Value.String())
+	if err != nil {
+		return err
+	}
+
+	psCmd, params, err := buildImportPsCmd(cmd, isWindowsImage)
 	if err != nil {
 		return err
 	}
@@ -80,6 +85,10 @@ func importImage(cmd *cobra.Command, args []string) error {
 			return common.CreateSystemNotInstalledCmdFailure()
 		}
 		return err
+	}
+
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s && isWindowsImage {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
 	}
 
 	outputWriter, err := common.NewOutputWriter()
@@ -103,7 +112,7 @@ func importImage(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func buildImportPsCmd(cmd *cobra.Command) (psCmd string, params []string, err error) {
+func buildImportPsCmd(cmd *cobra.Command, isWindowsImage bool) (psCmd string, params []string, err error) {
 	psCmd = utils.FormatScriptFilePath(filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "Import-Image.ps1"))
 
 	imagePath, err := cmd.Flags().GetString(tarFlag)
@@ -124,11 +133,6 @@ func buildImportPsCmd(cmd *cobra.Command) (psCmd string, params []string, err er
 		params = append(params, " -ImageDir '"+dir+"'")
 	} else {
 		return "", nil, errors.New("no path to oci archive provided")
-	}
-
-	isWindowsImage, err := strconv.ParseBool(cmd.Flags().Lookup(windowsFlag).Value.String())
-	if err != nil {
-		return "", nil, err
 	}
 
 	showOutput, err := strconv.ParseBool(cmd.Flags().Lookup(common.OutputFlagName).Value.String())

--- a/k2s/cmd/k2s/cmd/image/import_test.go
+++ b/k2s/cmd/k2s/cmd/image/import_test.go
@@ -28,7 +28,7 @@ var _ = Describe("import", Ordered, func() {
 			It("returns correct import command", func() {
 				importCmd.Flags().Set(tarFlag, "myImage")
 
-				cmd, params, err := buildImportPsCmd(importCmd)
+				cmd, params, err := buildImportPsCmd(importCmd, false)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "Import-Image.ps1") + "'"))
@@ -40,7 +40,7 @@ var _ = Describe("import", Ordered, func() {
 			It("returns correct import command", func() {
 				importCmd.Flags().Set(dirFlag, "myDir")
 
-				cmd, params, err := buildImportPsCmd(importCmd)
+				cmd, params, err := buildImportPsCmd(importCmd, false)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "Import-Image.ps1") + "'"))
@@ -53,7 +53,7 @@ var _ = Describe("import", Ordered, func() {
 				importCmd.Flags().Set(tarFlag, "myImage")
 				importCmd.Flags().Set(dirFlag, "myDir")
 
-				cmd, params, err := buildImportPsCmd(importCmd)
+				cmd, params, err := buildImportPsCmd(importCmd, false)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "Import-Image.ps1") + "'"))
@@ -63,7 +63,7 @@ var _ = Describe("import", Ordered, func() {
 
 		Context("without tar archieve and without directory", func() {
 			It("returns error", func() {
-				cmd, params, err := buildImportPsCmd(importCmd)
+				cmd, params, err := buildImportPsCmd(importCmd, false)
 
 				Expect(err).To(MatchError("no path to oci archive provided"))
 				Expect(cmd).To(BeEmpty())
@@ -74,10 +74,9 @@ var _ = Describe("import", Ordered, func() {
 		Context("with all flags", func() {
 			It("returns correct import command", func() {
 				importCmd.Flags().Set(tarFlag, "myImage")
-				importCmd.Flags().Set(windowsFlag, "true")
 				importCmd.Flags().Set(dockerArchiveFlag, "true")
 
-				cmd, params, err := buildImportPsCmd(importCmd)
+				cmd, params, err := buildImportPsCmd(importCmd, true)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "Import-Image.ps1") + "'"))

--- a/k2s/cmd/k2s/cmd/image/pull.go
+++ b/k2s/cmd/k2s/cmd/image/pull.go
@@ -91,6 +91,10 @@ func pullImage(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s && pullForWindows {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err

--- a/k2s/cmd/k2s/cmd/image/registry/add.go
+++ b/k2s/cmd/k2s/cmd/image/registry/add.go
@@ -83,6 +83,10 @@ func addRegistry(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err

--- a/k2s/cmd/k2s/cmd/image/registry/switch.go
+++ b/k2s/cmd/k2s/cmd/image/registry/switch.go
@@ -72,6 +72,10 @@ func switchRegistry(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err

--- a/k2s/cmd/k2s/cmd/image/remove.go
+++ b/k2s/cmd/k2s/cmd/image/remove.go
@@ -88,6 +88,10 @@ func removeImage(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->