### PR TITLE
renew old certificates when security addon is enabled

### DIFF
--- a/addons/security/Enable.ps1
+++ b/addons/security/Enable.ps1
@@ -125,6 +125,9 @@ if ($caCreated -ne $true) {
     exit 1
 }
 
+Write-Log 'Renewing old Certificates using the new CA Issuer' -Console
+Update-CertificateResources
+
 Write-Log 'Importing CA root certificate to trusted authorities of your computer' -Console
 $b64secret = (Invoke-Kubectl -Params '-n', 'cert-manager', 'get', 'secrets', 'ca-issuer-root-secret', '-o', 'jsonpath', '--template', '{.data.ca\.crt}').Output
 $tempFile = New-TemporaryFile

--- a/addons/security/security.module.psm1
+++ b/addons/security/security.module.psm1
@@ -84,6 +84,14 @@ function Wait-ForCertManagerAvailable {
 
 <#
 .DESCRIPTION
+Marks all cert-manager Certificate resources for renewal.
+#>
+function Update-CertificateResources {
+    &$cmctlExe renew --all --all-namespaces
+}
+
+<#
+.DESCRIPTION
 Waits for the kubernetes secret 'ca-issuer-root-secret' in the namespace 'cert-manager' to be created.
 #>
 function Wait-ForCARootCertificate(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation
Part of [security addon feature](https://github.com/Siemens-Healthineers/K2s/issues/258):  
When the add-on is enabled, cert-manager is now requested to renew all certificates,
using the new CA Issuer. This is needed for situations when the security addon was disabled,
leaving valid certificates in use - but the CA Issuer is removed from the computers trusted root certificates.
Re-enabling the plugin creates a new CA Issuer, imports this one in the trusted root - so the old certificates 
must all be renewed.

### Modifications

Invoke this after CA Issuer is created:

```script
cmctl.exe renew -all -all-namespaces
```
### Verification

manual tests

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->