### PR TITLE
#457 fix(multivm system CMDs): erroneous commands disabled

### DIFF
--- a/k2s/cmd/k2s/cmd/system/reset/reset.go
+++ b/k2s/cmd/k2s/cmd/system/reset/reset.go
@@ -46,6 +46,10 @@ func resetSystem(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err

--- a/k2s/cmd/k2s/cmd/system/scp/scp.go
+++ b/k2s/cmd/k2s/cmd/system/scp/scp.go
@@ -107,6 +107,11 @@ func runScpCmd(cmd *cobra.Command, args []string, scriptPath string) error {
 		return err
 	}
 
+	// TODO: disable copying to/from worker node for multivm
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s && scriptPath == scriptRelPathToScpWorker {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err

--- a/k2s/cmd/k2s/cmd/system/upgrade/upgrade.go
+++ b/k2s/cmd/k2s/cmd/system/upgrade/upgrade.go
@@ -94,6 +94,10 @@ func upgradeCluster(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if config.SetupName == setupinfo.SetupNameMultiVMK8s {
+		return common.CreateFunctionalityNotAvailableCmdFailure(config.SetupName)
+	}
+
 	psCmd := createUpgradeCommand(cmd)
 
 	slog.Debug("PS command created", "command", psCmd)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->