### PR TITLE
Chore(log): File logging is sufficient for nlasvc restart

### DIFF
--- a/lib/modules/k2s/k2s.node.module/windowsnode/network/network.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/windowsnode/network/network.module.psm1
@@ -272,7 +272,7 @@ function Restart-NlaSvc {
                     break
                 }
                 if ($iteration -ge 5) {
-                    Write-Log "'$networkLocationAwarenessServiceName' Service is not running !!" -Console
+                    Write-Log "'$networkLocationAwarenessServiceName' Service is not running !!"
                     break
                 }
                 Write-Log "'$networkLocationAwarenessServiceName' Waiting for service status to be started."
@@ -282,7 +282,7 @@ function Restart-NlaSvc {
         if ($serviceRestarted -eq $false) {
             Write-Log "[WARNING] '$networkLocationAwarenessServiceName' Service could not be successfully restarted !!" -Console
         } else {
-            Write-Log "Service re-started '$networkLocationAwarenessServiceName' " -Console
+            Write-Log "Service re-started '$networkLocationAwarenessServiceName' "
         }
 	}
 }


### PR DESCRIPTION
* Only the mandatory services or critical ones should be shown to the user. Rest of them to the files.
* Also, nlasvc is not relevant for the user from a cluster point of view.

