### PR TITLE
fix(docs): gateway-nginx no longer experimental

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -18,7 +18,7 @@ The following addons will be deployed with **K2s**:
 |---|---|
 | [dashboard](./dashboard/README.md) | Dashboard for Kubernetes | 
 | [exthttpaccess](./exthttpaccess/README.md) | Handle HTTP/HTTPS request coming to windows machine from local or external network | 
-| [gateway-nginx](./gateway-nginx/README.md) | EXPERIMENTAL: Gateway Controller for external access that provides an implementation of the Gateway API | 
+| [gateway-nginx](./gateway-nginx/README.md) | Gateway Controller for external access that provides an implementation of the Gateway API | 
 | [gpu-node](./gpu-node/README.md) | Configure KubeMaster as GPU node for direct GPU access | 
 | [ingress-nginx](./ingress-nginx/README.md) | Ingress Controller for external access that uses nginx as a reverse proxy | 
 | [kubevirt](./kubevirt/README.md) | Manage VM workloads with k2s | 

--- a/addons/gateway-nginx/addon.manifest.yaml
+++ b/addons/gateway-nginx/addon.manifest.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: AddonManifest
 metadata:
   name: gateway-nginx
-  description: "EXPERIMENTAL: Gateway Controller for external access that provides an implementation of the Gateway API"
+  description: "Gateway Controller for external access that provides an implementation of the Gateway API"
 spec:
   commands:
     enable:


### PR DESCRIPTION
gateway-nginx was already stable but docs were misleading. Fixed them.