### PR TITLE
fix(cli): Make missing param info as warning

### DIFF
--- a/k2s/cmd/k2s/cmd/addons/generic/generic.go
+++ b/k2s/cmd/k2s/cmd/addons/generic/generic.go
@@ -202,7 +202,7 @@ func convertToPsParam(flag *pflag.Flag, cmdConfig addons.AddonCmd, add func(stri
 	})
 
 	if !found {
-		slog.Debug("flag set, but not considered for parameterization", "flag", flag.Name, "value", flag.Value)
+		slog.Warn("CLI flag set, but missing PowerShell parameter mapping in `parameterMappings` of `addon.manifest.yaml`; not parameterized.", "flag", flag.Name, "value", flag.Value)
 		return nil
 	}
 


### PR DESCRIPTION
Improve the message from the cli