### PR TITLE
#258 feat(security): provide default ingress when missing

### DIFF
--- a/k2s/test/e2e/addons/security/security_test.go
+++ b/k2s/test/e2e/addons/security/security_test.go
@@ -127,6 +127,10 @@ var _ = Describe("'security' addon", Ordered, func() {
 		suite.K2sCli().Run(ctx, "addons", "disable", addonName, "-o")
 	})
 
+	It("disables default ingress addon", func(ctx context.Context) {
+		suite.K2sCli().Run(ctx, "addons", "disable", "ingress-nginx", "-o")
+	})
+
 	It("uninstalls cmctl.exe, the cert-manager CLI", func(ctx context.Context) {
 		cmCtlPath := path.Join(suite.RootDir(), "bin", "exe", "cmctl.exe")
 		_, err := os.Stat(cmCtlPath)


### PR DESCRIPTION
An Ingress controller is pre-requisite for security addon, so enabling default one if not present.
Adapted e2e test as well.