### PR TITLE
#348 refactor(install): Fixes force online installation

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
@@ -54,7 +54,7 @@ function New-ControlPlaneNodeOnNewVM {
 
     Set-ConfigWslFlag -Value $([bool]$WSL)
 
-    Invoke-DeployWinArtifacts -KubernetesVersion $KubernetesVersion -Proxy $Proxy
+    Invoke-DeployWinArtifacts -KubernetesVersion $KubernetesVersion -Proxy $Proxy -ForceOnlineInstallation:$ForceOnlineInstallation
     Install-PuttyTools
 
     $controlPlaneParams = @{

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/new-hyperv-vm-as-linuxnode.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/new-hyperv-vm-as-linuxnode.module.psm1
@@ -56,6 +56,7 @@ function New-LinuxVmAsControlPlaneNode {
             VMDiskSize = $VMDiskSize
             VMMemoryStartupBytes = $VMMemoryStartupBytes
             VMProcessorCount = $VMProcessorCount
+            ForceOnlineInstallation = $ForceOnlineInstallation
         }
         New-VmImageForControlPlaneNode @controlPlaneNodeCreationParams
     }


### PR DESCRIPTION
The value of the flag '-f' is passed through to the place where it is decided:
- if the zip file with the Windows node artifacts has to be created
- if the file Kubenode-Base.vhdx has to be created