### PR TITLE
fix(607): remove uninstall check from reset-win-storage command

### DIFF
--- a/k2s/cmd/k2s/cmd/common/common.go
+++ b/k2s/cmd/k2s/cmd/common/common.go
@@ -190,6 +190,10 @@ func DeterminePsVersion(config *setupinfo.Config) powershell.PowerShellVersion {
 	return powershell.PowerShellV5
 }
 
+func GetDefaultPsVersion() powershell.PowerShellVersion {
+	return powershell.PowerShellV5
+}
+
 func createErrorLineBuffer() (*logging.LogBuffer, error) {
 	return logging.NewLogBuffer(logging.BufferConfig{
 		Limit: 100,

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage.go
@@ -95,12 +95,17 @@ func resetWinStorage(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	psVersion := common.GetDefaultPsVersion()
+	if config != nil {
+		psVersion = common.DeterminePsVersion(config)
+	}
+
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {
 		return err
 	}
 
-	cmdResult, err := powershell.ExecutePsWithStructuredResult[*common.CmdResult](psCmd, "CmdResult", common.DeterminePsVersion(config), outputWriter, params...)
+	cmdResult, err := powershell.ExecutePsWithStructuredResult[*common.CmdResult](psCmd, "CmdResult", psVersion, outputWriter, params...)
 	if err != nil {
 		return err
 	}

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage.go
@@ -23,6 +23,38 @@ import (
 	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/common"
 )
 
+type setupConfigProvider interface {
+	LoadConfig(configDir string) (*setupinfo.Config, error)
+}
+
+type powershellExecutor interface {
+	ExecutePsWithStructuredResult(psVersion powershell.PowerShellVersion, psCmd string, params ...string) (*common.CmdResult, error)
+}
+
+type setupConfigProviderImpl struct{}
+
+type powershellExecutorImpl struct{}
+
+func (s *setupConfigProviderImpl) LoadConfig(configDir string) (*setupinfo.Config, error) {
+	return setupinfo.LoadConfig(configDir)
+}
+
+func (p *powershellExecutorImpl) ExecutePsWithStructuredResult(psVersion powershell.PowerShellVersion, psCmd string, params ...string) (*common.CmdResult, error) {
+	outputWriter, err := common.NewOutputWriter()
+	if err != nil {
+		return nil, err
+	}
+	return powershell.ExecutePsWithStructuredResult[*common.CmdResult](psCmd, "CmdResult", psVersion, outputWriter, params...)
+}
+
+func newSetupConfigProvider() setupConfigProvider {
+	return &setupConfigProviderImpl{}
+}
+
+func newPowershellExecutor() powershellExecutor {
+	return &powershellExecutorImpl{}
+}
+
 const (
 	containerdDirFlag     = "containerd"
 	dockerDirFlag         = "docker"
@@ -65,6 +97,9 @@ var (
 		RunE:    resetWinStorage,
 		Example: resetWinStorageCommandExample,
 	}
+
+	getSetupConfigProvider func() setupConfigProvider
+	getPowershellExecutor  func() powershellExecutor
 )
 
 func init() {
@@ -75,6 +110,9 @@ func init() {
 	resetWinStorageCmd.Flags().BoolP(forceFlag, forceFlagShorthand, false, "Trigger clean-up of windows container storage without user prompts")
 	resetWinStorageCmd.Flags().SortFlags = false
 	resetWinStorageCmd.Flags().PrintDefaults()
+
+	getSetupConfigProvider = newSetupConfigProvider
+	getPowershellExecutor = newPowershellExecutor
 }
 
 func resetWinStorage(cmd *cobra.Command, args []string) error {
@@ -87,8 +125,9 @@ func resetWinStorage(cmd *cobra.Command, args []string) error {
 
 	start := time.Now()
 
+	setupConfigProvider := getSetupConfigProvider()
 	configDir := cmd.Context().Value(common.ContextKeyConfigDir).(string)
-	config, err := setupinfo.LoadConfig(configDir)
+	config, err := setupConfigProvider.LoadConfig(configDir)
 	if err != nil {
 		if !(errors.Is(err, setupinfo.ErrSystemNotInstalled) || errors.Is(err, setupinfo.ErrSystemInCorruptedState)) {
 			return err
@@ -100,12 +139,8 @@ func resetWinStorage(cmd *cobra.Command, args []string) error {
 		psVersion = common.DeterminePsVersion(config)
 	}
 
-	outputWriter, err := common.NewOutputWriter()
-	if err != nil {
-		return err
-	}
-
-	cmdResult, err := powershell.ExecutePsWithStructuredResult[*common.CmdResult](psCmd, "CmdResult", psVersion, outputWriter, params...)
+	powershellExecutor := getPowershellExecutor()
+	cmdResult, err := powershellExecutor.ExecutePsWithStructuredResult(psVersion, psCmd, params...)
 	if err != nil {
 		return err
 	}

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/siemens-healthineers/k2s/cmd/k2s/utils"
 
+	"github.com/siemens-healthineers/k2s/internal/setupinfo"
+
 	"github.com/spf13/cobra"
 
 	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/common"
@@ -84,6 +86,13 @@ func resetWinStorage(cmd *cobra.Command, args []string) error {
 	slog.Debug("PS command created", "command", psCmd, "params", params)
 
 	start := time.Now()
+
+	configDir := cmd.Context().Value(common.ContextKeyConfigDir).(string)
+	config, err := setupinfo.LoadConfig(configDir)
+	if err != nil {
+		if !(errors.Is(err, setupinfo.ErrSystemNotInstalled) || errors.Is(err, setupinfo.ErrSystemInCorruptedState)) {
+		return err
+	}
 
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/siemens-healthineers/k2s/cmd/k2s/utils"
 
-	"github.com/siemens-healthineers/k2s/internal/setupinfo"
-
 	"github.com/spf13/cobra"
 
 	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/common"
@@ -86,18 +84,6 @@ func resetWinStorage(cmd *cobra.Command, args []string) error {
 	slog.Debug("PS command created", "command", psCmd, "params", params)
 
 	start := time.Now()
-
-	configDir := cmd.Context().Value(common.ContextKeyConfigDir).(string)
-	config, err := setupinfo.LoadConfig(configDir)
-	if err != nil {
-		if errors.Is(err, setupinfo.ErrSystemInCorruptedState) {
-			return common.CreateSystemInCorruptedStateCmdFailure()
-		}
-		if errors.Is(err, setupinfo.ErrSystemNotInstalled) {
-			return common.CreateSystemNotInstalledCmdFailure()
-		}
-		return err
-	}
 
 	outputWriter, err := common.NewOutputWriter()
 	if err != nil {

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage.go
@@ -91,7 +91,8 @@ func resetWinStorage(cmd *cobra.Command, args []string) error {
 	config, err := setupinfo.LoadConfig(configDir)
 	if err != nil {
 		if !(errors.Is(err, setupinfo.ErrSystemNotInstalled) || errors.Is(err, setupinfo.ErrSystemInCorruptedState)) {
-		return err
+			return err
+		}
 	}
 
 	outputWriter, err := common.NewOutputWriter()

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage_test.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage_test.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText:  © 2023 Siemens Healthcare GmbH
+// SPDX-License-Identifier:   MIT
+
+package image
+
+import (
+	"errors"
+	"path/filepath"
+	"strconv"
+
+	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/common"
+	"github.com/siemens-healthineers/k2s/cmd/k2s/utils"
+	"github.com/siemens-healthineers/k2s/internal/powershell"
+	"github.com/siemens-healthineers/k2s/internal/setupinfo"
+	"github.com/stretchr/testify/mock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type mockSetupConfigProvider struct {
+	mock.Mock
+}
+
+func (m *mockSetupConfigProvider) LoadConfig(configDir string) (*setupinfo.Config, error) {
+	args := m.Called()
+	return args.Get(0).(*setupinfo.Config), args.Error(1)
+}
+
+type mockPowershellExecutor struct {
+	mock.Mock
+}
+
+func (m *mockPowershellExecutor) ExecutePsWithStructuredResult(psVersion powershell.PowerShellVersion, psCmd string, params ...string) (*common.CmdResult, error) {
+	args := m.Called(psVersion, psCmd, params)
+	return args.Get(0).(*common.CmdResult), args.Error(1)
+}
+
+var _ = Describe("reset-win-storage", func() {
+	Describe("buildResetPsCmd", func() {
+		Context("with containerd directory and docker directory", func() {
+			It("returns correct reset-win-storage command", func() {
+				resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+				resetWinStorageCmd.Flags().Set(dockerDirFlag, "dockerDir")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf("-Containerd", "containerdDir", "-Docker", "dockerDir", "-MaxRetries", strconv.Itoa(defaultMaxRetry)))
+			})
+		})
+
+		Context("with containerd directory only", func() {
+			It("returns correct reset-win-storage command", func() {
+				resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf("-Containerd", "containerdir", "-MaxRetries", strconv.Itoa(defaultMaxRetry)))
+			})
+		})
+
+		Context("with docker directory only", func() {
+			It("returns correct reset-win-storage command", func() {
+				resetWinStorageCmd.Flags().Set(dockerDirFlag, "dockerDir")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinDockerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf("-Docker", "dockerDir", "MaxRetries", strconv.Itoa(defaultMaxRetry)))
+			})
+		})
+
+		Context("with no directory and user provided retries", func() {
+			It("returns correct reset-win-storage command with default directories and user provided retries", func() {
+				resetWinStorageCmd.Flags().Set(maxRetryFlag, "5")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf("-Containerd", defaultContainerdDir, "-Docker", defaultDockerDir, "-MaxRetries", "5"))
+			})
+		})
+
+		Context("with force zap flag", func() {
+			It("returns correct reset-win-storage command with force zap flag", func() {
+				resetWinStorageCmd.Flags().Set(forceZapFlag, "true")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf("-Containerd", defaultContainerdDir, "-Docker", defaultDockerDir, "-MaxRetries", strconv.Itoa(defaultMaxRetry), "-ForceZap"))
+			})
+		})
+	})
+
+	Describe("resetWinStorage", func() {
+		Context("when k2s is not installed", func() {
+			It("command is executed", func() {
+				mockSetupConfigProvider := &mockSetupConfigProvider{}
+				mockPowershellExecutor := &mockPowershellExecutor{}
+				mockSetupConfigProvider.On("LoadConfig").Return(nil, setupinfo.ErrSystemNotInstalled)
+				getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+				getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+				resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+				resetWinStorage(resetWinStorageCmd, nil)
+
+				mockPowershellExecutor.AssertCalled(GinkgoT(), "ExecutePsWithStructuredResult", common.GetDefaultPsVersion(), "&'"+filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1")+"'", "-Containerd", "containerdDir", "-Docker", defaultDockerDir, "-MaxRetries", strconv.Itoa(defaultMaxRetry))
+			})
+		})
+
+		Context("when k2s installation is corrupted", func() {
+			Context("when default k2s variant", func() {
+				It("command is executed", func() {
+					mockSetupConfigProvider := &mockSetupConfigProvider{}
+					mockPowershellExecutor := &mockPowershellExecutor{}
+					config := &setupinfo.Config{
+						Corrupted: true,
+					}
+					mockSetupConfigProvider.On("LoadConfig").Return(config, setupinfo.ErrSystemInCorruptedState)
+					getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+					getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+					resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+					resetWinStorage(resetWinStorageCmd, nil)
+
+					mockPowershellExecutor.AssertCalled(GinkgoT(), "ExecutePsWithStructuredResult", common.GetDefaultPsVersion(), "&'"+filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1")+"'", "-Containerd", "containerdDir", "-Docker", defaultDockerDir, "-MaxRetries", strconv.Itoa(defaultMaxRetry))
+				})
+			})
+			Context("when MultiVMK8s variant", func() {
+				It("command is executed", func() {
+					mockSetupConfigProvider := &mockSetupConfigProvider{}
+					mockPowershellExecutor := &mockPowershellExecutor{}
+					config := &setupinfo.Config{
+						Corrupted: true,
+						SetupName: setupinfo.SetupNameMultiVMK8s,
+					}
+					mockSetupConfigProvider.On("LoadConfig").Return(config, setupinfo.ErrSystemInCorruptedState)
+					getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+					getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+					resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+					resetWinStorage(resetWinStorageCmd, nil)
+
+					mockPowershellExecutor.AssertCalled(GinkgoT(), "ExecutePsWithStructuredResult", common.GetDefaultPsVersion(), "&'"+filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1")+"'", "-Containerd", "containerdDir", "-Docker", defaultDockerDir, "-MaxRetries", strconv.Itoa(defaultMaxRetry))
+				})
+			})
+			Context("when Linux-only variant", func() {
+				It("command is executed", func() {
+					mockSetupConfigProvider := &mockSetupConfigProvider{}
+					mockPowershellExecutor := &mockPowershellExecutor{}
+					config := &setupinfo.Config{
+						Corrupted: true,
+						LinuxOnly: true,
+					}
+					mockSetupConfigProvider.On("LoadConfig").Return(config, setupinfo.ErrSystemInCorruptedState)
+					getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+					getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+					resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+					resetWinStorage(resetWinStorageCmd, nil)
+
+					mockPowershellExecutor.AssertCalled(GinkgoT(), "ExecutePsWithStructuredResult", common.GetDefaultPsVersion(), "&'"+filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1")+"'", "-Containerd", "containerdDir", "-Docker", defaultDockerDir, "-MaxRetries", strconv.Itoa(defaultMaxRetry))
+				})
+			})
+		})
+
+		Context("when k2s is installed", func() {
+			Context("error encountered while reading setup details", func() {
+				It("returns error", func() {
+					mockSetupConfigProvider := &mockSetupConfigProvider{}
+					mockPowershellExecutor := &mockPowershellExecutor{}
+					err := errors.New("error")
+					mockSetupConfigProvider.On("LoadConfig").Return(nil, err)
+					getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+					getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+					resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+					errFromCmdExecution := resetWinStorage(resetWinStorageCmd, nil)
+
+					Expect(errFromCmdExecution).To(HaveOccurred())
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
Fixed implementation of reset-win-storage to let it execute even when k2s is not installed.
This is required to address the usecase that the user may want to clean up docker and containerd directories when the user has uninstalled k2s.

Similarly, reset-win-storage command must be executed when k2s is in corrupted state.

Added unit tests to validate that the reset-win-storage command is executed even when k2s is uninstalled or in corrupted state.