### PR TITLE
fix(image pull): Fixes lookup of function 'Get-KubeBinPath'

### DIFF
--- a/lib/modules/k2s/k2s.node.module/windowsnode/services/services.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/windowsnode/services/services.module.psm1
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
 # SPDX-License-Identifier: MIT
 
-$logModule = "$PSScriptRoot\..\..\..\k2s.infra.module\log\log.module.psm1"
+$infraModule = "$PSScriptRoot\..\..\..\k2s.infra.module\k2s.infra.module.psm1"
 $loopBackAdapterModule = "$PSScriptRoot\..\network\loopbackadapter.module.psm1"
-Import-Module $logModule, $loopBackAdapterModule
+Import-Module $infraModule, $loopBackAdapterModule
 
 $kubeBinPath = Get-KubeBinPath
 


### PR DESCRIPTION
Done by importing the module k2s.infra.module.psm1 into the module that calls the function 'Get-KubeBinPath'