### PR TITLE
chore(e2e): add markers for windows image

### DIFF
--- a/k2s/test/e2e/cluster/core/workload/windows/windows-albums.yaml
+++ b/k2s/test/e2e/cluster/core/workload/windows/windows-albums.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: albums-win1
-          image: shsk2s.azurecr.io/example.albums-golang-win:v1.0.0
+          image: shsk2s.azurecr.io/example.albums-golang-win:v1.0.0 #windows_image
           ports:
             - containerPort: 80
           env:
@@ -64,7 +64,7 @@ spec:
     spec:
       containers:
         - name: albums-win2
-          image: shsk2s.azurecr.io/example.albums-golang-win:v1.0.0
+          image: shsk2s.azurecr.io/example.albums-golang-win:v1.0.0 #windows_image
           ports:
             - containerPort: 80
           env:


### PR DESCRIPTION
Add markers for windows image for offline pull usecases.