### PR TITLE
fix(607): remove uninstall check from reset-win-storage command

### DIFF
--- a/k2s/cmd/k2s/cmd/common/common.go
+++ b/k2s/cmd/k2s/cmd/common/common.go
@@ -198,6 +198,10 @@ func DeterminePsVersion(config *setupinfo.Config) powershell.PowerShellVersion {
 	return powershell.PowerShellV5
 }
 
+func GetDefaultPsVersion() powershell.PowerShellVersion {
+	return powershell.PowerShellV5
+}
+
 func createErrorLineBuffer() (*logging.LogBuffer, error) {
 	return logging.NewLogBuffer(logging.BufferConfig{
 		Limit: 100,

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage.go
@@ -24,6 +24,38 @@ import (
 	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/common"
 )
 
+type setupConfigProvider interface {
+	ReadConfig(configDir string) (*setupinfo.Config, error)
+}
+
+type powershellExecutor interface {
+	ExecutePsWithStructuredResult(psVersion powershell.PowerShellVersion, psCmd string, params ...string) (*common.CmdResult, error)
+}
+
+type setupConfigProviderImpl struct{}
+
+type powershellExecutorImpl struct{}
+
+func (s *setupConfigProviderImpl) ReadConfig(configDir string) (*setupinfo.Config, error) {
+	return setupinfo.ReadConfig(configDir)
+}
+
+func (p *powershellExecutorImpl) ExecutePsWithStructuredResult(psVersion powershell.PowerShellVersion, psCmd string, params ...string) (*common.CmdResult, error) {
+	outputWriter, err := common.NewOutputWriter()
+	if err != nil {
+		return nil, err
+	}
+	return powershell.ExecutePsWithStructuredResult[*common.CmdResult](psCmd, "CmdResult", psVersion, outputWriter, params...)
+}
+
+func newSetupConfigProvider() setupConfigProvider {
+	return &setupConfigProviderImpl{}
+}
+
+func newPowershellExecutor() powershellExecutor {
+	return &powershellExecutorImpl{}
+}
+
 const (
 	containerdDirFlag     = "containerd"
 	dockerDirFlag         = "docker"
@@ -66,6 +98,9 @@ var (
 		RunE:    resetWinStorage,
 		Example: resetWinStorageCommandExample,
 	}
+
+	getSetupConfigProvider func() setupConfigProvider
+	getPowershellExecutor  func() powershellExecutor
 )
 
 func init() {
@@ -76,6 +111,9 @@ func init() {
 	resetWinStorageCmd.Flags().BoolP(forceFlag, forceFlagShorthand, false, "Trigger clean-up of windows container storage without user prompts")
 	resetWinStorageCmd.Flags().SortFlags = false
 	resetWinStorageCmd.Flags().PrintDefaults()
+
+	getSetupConfigProvider = newSetupConfigProvider
+	getPowershellExecutor = newPowershellExecutor
 }
 
 func resetWinStorage(cmd *cobra.Command, args []string) error {
@@ -88,24 +126,23 @@ func resetWinStorage(cmd *cobra.Command, args []string) error {
 
 	start := time.Now()
 
+	setupConfigProvider := getSetupConfigProvider()
 	cfg := cmd.Context().Value(common.ContextKeyConfig).(*config.Config)
-	config, err := setupinfo.ReadConfig(cfg.Host.K2sConfigDir)
+	config, err := setupConfigProvider.ReadConfig(cfg.Host.K2sConfigDir)
 	if err != nil {
-		if errors.Is(err, setupinfo.ErrSystemInCorruptedState) {
-			return common.CreateSystemInCorruptedStateCmdFailure()
+		if !(errors.Is(err, setupinfo.ErrSystemNotInstalled) || errors.Is(err, setupinfo.ErrSystemInCorruptedState)) {
+			return err
 		}
-		if errors.Is(err, setupinfo.ErrSystemNotInstalled) {
-			return common.CreateSystemNotInstalledCmdFailure()
-		}
-		return err
 	}
 
-	outputWriter, err := common.NewOutputWriter()
-	if err != nil {
-		return err
+	psVersion := common.GetDefaultPsVersion()
+	if config != nil {
+		psVersion = common.DeterminePsVersion(config)
 	}
 
-	cmdResult, err := powershell.ExecutePsWithStructuredResult[*common.CmdResult](psCmd, "CmdResult", common.DeterminePsVersion(config), outputWriter, params...)
+	powershellExecutor := getPowershellExecutor()
+	cmdResult, err := powershellExecutor.ExecutePsWithStructuredResult(psVersion, psCmd, params...)
+
 	if err != nil {
 		return err
 	}

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage_test.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage_test.go
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText:  © 2023 Siemens Healthcare GmbH
+// SPDX-License-Identifier:   MIT
+
+package image
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+
+	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/common"
+	"github.com/siemens-healthineers/k2s/cmd/k2s/utils"
+	"github.com/siemens-healthineers/k2s/internal/powershell"
+	"github.com/siemens-healthineers/k2s/internal/reflection"
+	"github.com/siemens-healthineers/k2s/internal/setupinfo"
+	"github.com/stretchr/testify/mock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type mockSetupConfigProvider struct {
+	mock.Mock
+}
+
+func (m *mockSetupConfigProvider) ReadConfig(configDir string) (*setupinfo.Config, error) {
+	args := m.Called(configDir)
+	return args.Get(0).(*setupinfo.Config), args.Error(1)
+}
+
+type mockPowershellExecutor struct {
+	mock.Mock
+}
+
+func (m *mockPowershellExecutor) ExecutePsWithStructuredResult(psVersion powershell.PowerShellVersion, psCmd string, params ...string) (*common.CmdResult, error) {
+	args := m.Called(psVersion, psCmd, params)
+	return args.Get(0).(*common.CmdResult), args.Error(1)
+}
+
+var _ = Describe("reset-win-storage", Ordered, func() {
+	BeforeAll(func() {
+		resetWinStorageCmd.Flags().BoolP(common.OutputFlagName, common.OutputFlagShorthand, false, common.OutputFlagUsage)
+	})
+	BeforeEach(func() {
+		resetFlags()
+
+		DeferCleanup(resetFlags)
+	})
+	Describe("buildResetPsCmd", func() {
+		Context("with containerd directory and docker directory", func() {
+			It("returns correct reset-win-storage command", func() {
+				resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+				resetWinStorageCmd.Flags().Set(dockerDirFlag, "dockerDir")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf(" -Containerd 'containerdDir'", " -Docker 'dockerDir'", fmt.Sprintf(" -MaxRetries %v", strconv.Itoa(defaultMaxRetry))))
+			})
+		})
+
+		Context("with containerd directory only", func() {
+			It("returns correct reset-win-storage command", func() {
+				resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf(" -Containerd 'containerdDir'", fmt.Sprintf(" -Docker '%v'", defaultDockerDir), fmt.Sprintf(" -MaxRetries %v", strconv.Itoa(defaultMaxRetry))))
+			})
+		})
+
+		Context("with docker directory only", func() {
+			It("returns correct reset-win-storage command", func() {
+				resetWinStorageCmd.Flags().Set(dockerDirFlag, "dockerDir")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf(fmt.Sprintf(" -Containerd '%v'", defaultContainerdDir), " -Docker 'dockerDir'", fmt.Sprintf(" -MaxRetries %v", strconv.Itoa(defaultMaxRetry))))
+			})
+		})
+
+		Context("with no directory and user provided retries", func() {
+			It("returns correct reset-win-storage command with default directories and user provided retries", func() {
+				resetWinStorageCmd.Flags().Set(maxRetryFlag, "5")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf(fmt.Sprintf(" -Containerd '%v'", defaultContainerdDir), fmt.Sprintf(" -Docker '%v'", defaultDockerDir), fmt.Sprintf(" -MaxRetries %v", strconv.Itoa(5))))
+			})
+		})
+
+		Context("with force zap flag", func() {
+			It("returns correct reset-win-storage command with force zap flag", func() {
+				resetWinStorageCmd.Flags().Set(forceZapFlag, "true")
+
+				cmd, params, err := buildResetPsCmd(resetWinStorageCmd)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cmd).To(Equal("&'" + filepath.Join(utils.InstallDir(), "lib", "scripts", "k2s", "image", "ResetWinContainerStorage.ps1") + "'"))
+				Expect(params).To(ConsistOf(fmt.Sprintf(" -Containerd '%v'", defaultContainerdDir), fmt.Sprintf(" -Docker '%v'", defaultDockerDir), fmt.Sprintf(" -MaxRetries %v", strconv.Itoa(defaultMaxRetry)), " -ForceZap"))
+			})
+		})
+	})
+
+	Describe("resetWinStorage", func() {
+		Context("when k2s is not installed", func() {
+			It("command is executed", func() {
+				mockSetupConfigProvider := &mockSetupConfigProvider{}
+				mockPowershellExecutor := &mockPowershellExecutor{}
+				var nilConfig *setupinfo.Config
+				mockSetupConfigProvider.On(reflection.GetFunctionName(mockSetupConfigProvider.ReadConfig), mock.AnythingOfType("string")).Return(nilConfig, setupinfo.ErrSystemNotInstalled)
+				mockPowershellExecutor.On(reflection.GetFunctionName(mockPowershellExecutor.ExecutePsWithStructuredResult), mock.Anything, mock.Anything, mock.Anything).Return(&common.CmdResult{}, nil)
+				getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+				getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+				resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+				resetWinStorage(resetWinStorageCmd, nil)
+
+				mockPowershellExecutor.AssertCalled(GinkgoT(), reflection.GetFunctionName(mockPowershellExecutor.ExecutePsWithStructuredResult), mock.Anything, mock.Anything, mock.Anything)
+			})
+		})
+
+		Context("when k2s installation is corrupted", func() {
+			Context("when default k2s variant", func() {
+				It("command is executed", func() {
+					mockSetupConfigProvider := &mockSetupConfigProvider{}
+					mockPowershellExecutor := &mockPowershellExecutor{}
+					config := &setupinfo.Config{
+						Corrupted: true,
+					}
+					mockSetupConfigProvider.On(reflection.GetFunctionName(mockSetupConfigProvider.ReadConfig), mock.AnythingOfType("string")).Return(config, setupinfo.ErrSystemInCorruptedState)
+					mockPowershellExecutor.On(reflection.GetFunctionName(mockPowershellExecutor.ExecutePsWithStructuredResult), mock.Anything, mock.Anything, mock.Anything).Return(&common.CmdResult{}, nil)
+					getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+					getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+					resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+					resetWinStorage(resetWinStorageCmd, nil)
+
+					mockPowershellExecutor.AssertCalled(GinkgoT(), reflection.GetFunctionName(mockPowershellExecutor.ExecutePsWithStructuredResult), mock.Anything, mock.Anything, mock.Anything)
+				})
+			})
+			Context("when MultiVMK8s variant", func() {
+				It("command is executed", func() {
+					mockSetupConfigProvider := &mockSetupConfigProvider{}
+					mockPowershellExecutor := &mockPowershellExecutor{}
+					config := &setupinfo.Config{
+						Corrupted: true,
+						SetupName: setupinfo.SetupNameMultiVMK8s,
+					}
+					mockSetupConfigProvider.On(reflection.GetFunctionName(mockSetupConfigProvider.ReadConfig), mock.AnythingOfType("string")).Return(config, setupinfo.ErrSystemInCorruptedState)
+					mockPowershellExecutor.On(reflection.GetFunctionName(mockPowershellExecutor.ExecutePsWithStructuredResult), mock.Anything, mock.Anything, mock.Anything).Return(&common.CmdResult{}, nil)
+					getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+					getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+					resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+					resetWinStorage(resetWinStorageCmd, nil)
+
+					mockPowershellExecutor.AssertCalled(GinkgoT(), reflection.GetFunctionName(mockPowershellExecutor.ExecutePsWithStructuredResult), mock.Anything, mock.Anything, mock.Anything)
+				})
+			})
+			Context("when Linux-only variant", func() {
+				It("command is executed", func() {
+					mockSetupConfigProvider := &mockSetupConfigProvider{}
+					mockPowershellExecutor := &mockPowershellExecutor{}
+					config := &setupinfo.Config{
+						Corrupted: true,
+						LinuxOnly: true,
+					}
+					mockSetupConfigProvider.On(reflection.GetFunctionName(mockSetupConfigProvider.ReadConfig), mock.AnythingOfType("string")).Return(config, setupinfo.ErrSystemInCorruptedState)
+					mockPowershellExecutor.On(reflection.GetFunctionName(mockPowershellExecutor.ExecutePsWithStructuredResult), mock.Anything, mock.Anything, mock.Anything).Return(&common.CmdResult{}, nil)
+					getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+					getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+					resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+					resetWinStorage(resetWinStorageCmd, nil)
+
+					mockPowershellExecutor.AssertCalled(GinkgoT(), reflection.GetFunctionName(mockPowershellExecutor.ExecutePsWithStructuredResult), mock.Anything, mock.Anything, mock.Anything)
+				})
+			})
+		})
+
+		Context("when k2s is installed", func() {
+			Context("error encountered while reading setup details", func() {
+				It("returns error", func() {
+					mockSetupConfigProvider := &mockSetupConfigProvider{}
+					mockPowershellExecutor := &mockPowershellExecutor{}
+					err := errors.New("error")
+					var nilConfig *setupinfo.Config
+					mockSetupConfigProvider.On(reflection.GetFunctionName(mockSetupConfigProvider.ReadConfig), mock.AnythingOfType("string")).Return(nilConfig, err)
+					mockPowershellExecutor.On(reflection.GetFunctionName(mockPowershellExecutor.ExecutePsWithStructuredResult), mock.Anything, mock.Anything, mock.Anything).Return(&common.CmdResult{}, nil)
+					getSetupConfigProvider = func() setupConfigProvider { return mockSetupConfigProvider }
+					getPowershellExecutor = func() powershellExecutor { return mockPowershellExecutor }
+					resetWinStorageCmd.Flags().Set(containerdDirFlag, "containerdDir")
+
+					errFromCmdExecution := resetWinStorage(resetWinStorageCmd, nil)
+
+					Expect(errFromCmdExecution).To(HaveOccurred())
+				})
+			})
+		})
+	})
+})
+
+func resetFlags() {
+	resetWinStorageCmd.Flags().Set(containerdDirFlag, "")
+	resetWinStorageCmd.Flags().Set(dockerDirFlag, "")
+	resetWinStorageCmd.Flags().Set(maxRetryFlag, "1")
+	resetWinStorageCmd.Flags().Set(forceZapFlag, "false")
+	resetWinStorageCmd.SetContext(context.WithValue(context.TODO(), common.ContextKeyConfig, "some-dir"))
+}

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage_test.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/common"
 	"github.com/siemens-healthineers/k2s/cmd/k2s/utils"
+	cfg "github.com/siemens-healthineers/k2s/internal/config"
 	"github.com/siemens-healthineers/k2s/internal/powershell"
 	"github.com/siemens-healthineers/k2s/internal/reflection"
 	"github.com/siemens-healthineers/k2s/internal/setupinfo"
@@ -215,5 +216,5 @@ func resetFlags() {
 	resetWinStorageCmd.Flags().Set(dockerDirFlag, "")
 	resetWinStorageCmd.Flags().Set(maxRetryFlag, "1")
 	resetWinStorageCmd.Flags().Set(forceZapFlag, "false")
-	resetWinStorageCmd.SetContext(context.WithValue(context.TODO(), common.ContextKeyConfig, &cfg.Config{Host: cfg.HostConfig{K2sConfigDir: "some-dir"}})))
+	resetWinStorageCmd.SetContext(context.WithValue(context.TODO(), common.ContextKeyConfig, &cfg.Config{Host: cfg.HostConfig{K2sConfigDir: "some-dir"}}))
 }

--- a/k2s/cmd/k2s/cmd/image/resetwinstorage_test.go
+++ b/k2s/cmd/k2s/cmd/image/resetwinstorage_test.go
@@ -215,5 +215,5 @@ func resetFlags() {
 	resetWinStorageCmd.Flags().Set(dockerDirFlag, "")
 	resetWinStorageCmd.Flags().Set(maxRetryFlag, "1")
 	resetWinStorageCmd.Flags().Set(forceZapFlag, "false")
-	resetWinStorageCmd.SetContext(context.WithValue(context.TODO(), common.ContextKeyConfig, "some-dir"))
+	resetWinStorageCmd.SetContext(context.WithValue(context.TODO(), common.ContextKeyConfig, &cfg.Config{Host: cfg.HostConfig{K2sConfigDir: "some-dir"}})))
 }


### PR DESCRIPTION
Fixed implementation of reset-win-storage to let it execute even when k2s is not installed.
This is required to address the usecase that the user may want to clean up docker and containerd directories when the user has uninstalled k2s.

Similarly, reset-win-storage command must be executed when k2s is in corrupted state.

Added unit tests to validate that the reset-win-storage command is executed even when k2s is uninstalled or in corrupted state.