### PR TITLE
fix: fix corrupted state tests for reset-win-storage command

### DIFF
--- a/k2s/test/e2e/cli/cmd/image/nosetup/corruptedstate/image_corrupted-state_test.go
+++ b/k2s/test/e2e/cli/cmd/image/nosetup/corruptedstate/image_corrupted-state_test.go
@@ -100,7 +100,6 @@ var _ = Describe("image", Ordered, func() {
 		Entry("registry ls", "image", "registry", "ls"),
 		Entry("registry switch", "image", "registry", "switch", "non-existent"),
 		Entry("rm", "image", "rm", "--id", "non-existent"),
-		Entry("reset-win-storage", "image", "reset-win-storage"),
 	)
 
 	Describe("ls JSON output", Ordered, func() {


### PR DESCRIPTION
fixed corrupted-state image tests for reset-win-storage command