### PR TITLE
feat(cli): removed critical error msg and dump stack only during panic

### DIFF
--- a/k2s/cmd/k2s/main.go
+++ b/k2s/cmd/k2s/main.go
@@ -17,8 +17,6 @@ import (
 	"github.com/pterm/pterm"
 )
 
-const generalErrMsg = "critical error occurred during command execution, aborting"
-
 func main() {
 	exitCode := 0
 
@@ -50,7 +48,7 @@ func main() {
 
 	var cmdFailure *common.CmdFailure
 	if !errors.As(err, &cmdFailure) {
-		handleUnexpectedError(err)
+		pterm.Error.Println(fmt.Errorf("%v", err))
 		return
 	}
 
@@ -75,7 +73,6 @@ func main() {
 }
 
 func handleUnexpectedError(err any) {
-	pterm.Error.Println(fmt.Errorf("%s: %v", generalErrMsg, err))
-
-	slog.Error(generalErrMsg, "error", err, "stack", string(debug.Stack()))
+	pterm.Error.Println(fmt.Errorf("%v", err))
+	slog.Error("error", err, "stack", string(debug.Stack()))
 }


### PR DESCRIPTION
Dump stack to user only when there is a panic in golang. Removed critical error message.