### PR TITLE
feat(install): distinction of pre-req and install failure

### DIFF
--- a/k2s/cmd/k2s/cmd/install/core/installer.go
+++ b/k2s/cmd/k2s/cmd/install/core/installer.go
@@ -28,6 +28,7 @@ type InstallConfigAccess interface {
 
 type Printer interface {
 	Printfln(format string, m ...any)
+	PrintWarning(m ...any)
 }
 
 type Installer struct {
@@ -40,6 +41,7 @@ type Installer struct {
 	PrintCompletedMessageFunc func(duration time.Duration, command string)
 	LoadConfigFunc            func(configDir string) (*setupinfo.Config, error)
 	SetConfigFunc             func(configDir string, config *setupinfo.Config) error
+	DeleteConfigFunc          func(configDir string) error
 }
 
 func (i *Installer) Install(
@@ -89,25 +91,37 @@ func (i *Installer) Install(
 
 	err = i.ExecutePsScript(cmd, psVersion, outputWriter)
 	if err != nil {
-		return err
-	}
-
-	if outputWriter.ErrorOccurred {
-		// corrupted state
-		setupConfig, err := i.LoadConfigFunc(cfg.Host.K2sConfigDir)
-		if err != nil {
-			if setupConfig == nil {
-				setupConfig = &setupinfo.Config{
-					Corrupted: true,
-				}
-				i.SetConfigFunc(cfg.Host.K2sConfigDir, setupConfig)
+		// Check for pre-requisites first
+		errorLine, found := common.GetInstallPreRequisiteError(outputWriter.ErrorLines)
+		if found {
+			i.Printer.PrintWarning("Prerequisite check failed,", errorLine)
+			i.Printer.PrintWarning("Have a look at the pre-requisites https://github.com/Siemens-Healthineers/K2s and re-issue 'k2s install'")
+			err = i.DeleteConfigFunc(cfg.Host.K2sConfigDir)
+			if err != nil {
+				slog.Debug("config file does not exist, nothing to do")
 			}
-		} else {
-			setupConfig.Corrupted = true
-			i.SetConfigFunc(cfg.Host.K2sConfigDir, setupConfig)
+			return nil
 		}
 
-		return common.CreateSystemInCorruptedStateCmdFailure()
+		if outputWriter.ErrorOccurred {
+			// corrupted state
+			setupConfig, err := i.LoadConfigFunc(cfg.Host.K2sConfigDir)
+			if err != nil {
+				if setupConfig == nil {
+					setupConfig = &setupinfo.Config{
+						Corrupted: true,
+					}
+					i.SetConfigFunc(cfg.Host.K2sConfigDir, setupConfig)
+				}
+			} else {
+				setupConfig.Corrupted = true
+				i.SetConfigFunc(cfg.Host.K2sConfigDir, setupConfig)
+			}
+
+			return common.CreateSystemInCorruptedStateCmdFailure()
+		}
+
+		return err
 	}
 
 	duration := time.Since(start)

--- a/k2s/cmd/k2s/cmd/install/core/installer_test.go
+++ b/k2s/cmd/k2s/cmd/install/core/installer_test.go
@@ -42,10 +42,20 @@ func (m *myMock) Printfln(format string, a ...any) {
 	m.Called(format, a)
 }
 
+func (m *myMock) PrintWarning(a ...any) {
+	m.Called(a)
+}
+
 func (m *myMock) loadConfig(configDir string) (*setupinfo.Config, error) {
 	args := m.Called(configDir)
 
 	return args.Get(0).(*setupinfo.Config), args.Error(1)
+}
+
+func (m *myMock) deleteConfig(configDir string) error {
+	args := m.Called(configDir)
+
+	return args.Error(0)
 }
 
 func (m *myMock) Load(kind ic.Kind, cmdFlags *pflag.FlagSet) (*ic.InstallConfig, error) {
@@ -202,6 +212,7 @@ var _ = Describe("core", func() {
 
 				printerMock := &myMock{}
 				printerMock.On(r.GetFunctionName(printerMock.Printfln), mock.Anything, mock.Anything)
+				printerMock.On(r.GetFunctionName(printerMock.PrintWarning), mock.Anything, mock.Anything)
 
 				configMock := &myMock{}
 				configMock.On(reflection.GetFunctionName(configMock.loadConfig), "some-dir").Return(nilConfig, setupinfo.ErrSystemNotInstalled)
@@ -211,6 +222,8 @@ var _ = Describe("core", func() {
 
 				executorMock := &myMock{}
 				executorMock.On(r.GetFunctionName(executorMock.ExecutePs), testCmd, powershell.PowerShellV5, mock.AnythingOfType("*common.OutputWriter")).Return(expectedError)
+				executorMock.On(r.GetFunctionName(executorMock.ExecutePs), testCmd, powershell.PowerShellV5, mock.AnythingOfType("*common.OutputWriter.ErrorLines")).Return("[PREREQ-FAILED] pre-requisite failed")
+				executorMock.On(r.GetFunctionName(executorMock.ExecutePs), testCmd, powershell.PowerShellV5, mock.AnythingOfType("*common.GetInstallPreRequisiteError")).Return("[PREREQ-FAILED] pre-requisite failed", true)
 
 				sut := &core.Installer{
 					Printer:             printerMock,
@@ -225,6 +238,57 @@ var _ = Describe("core", func() {
 				err := sut.Install(kind, cmd, buildCmdFunc)
 
 				Expect(err).To(MatchError(expectedError))
+			})
+		})
+
+		When("pre-requisites check fails while executing command ", func() {
+			It("returns prints warning", func() {
+				kind := ic.Kind("test-kind")
+				cmd := &cobra.Command{}
+				cmd.SetContext(context.WithValue(context.TODO(), common.ContextKeyConfig, &cfg.Config{Host: cfg.HostConfig{K2sConfigDir: "some-dir"}}))
+
+				config := &ic.InstallConfig{}
+				testCmd := "test-cmd"
+				expectedError := errors.New("oops")
+				var nilConfig *setupinfo.Config
+
+				buildCmdFunc := func(c *ic.InstallConfig) (cmd string, err error) {
+					Expect(c).To(Equal(config))
+					return testCmd, nil
+				}
+
+				printerMock := &myMock{}
+				printerMock.On(r.GetFunctionName(printerMock.Printfln), mock.Anything, mock.Anything)
+				printerMock.On(r.GetFunctionName(printerMock.PrintWarning), mock.Anything, mock.Anything)
+
+				configMock := &myMock{}
+				configMock.On(reflection.GetFunctionName(configMock.loadConfig), "some-dir").Return(nilConfig, setupinfo.ErrSystemNotInstalled)
+				configMock.On(reflection.GetFunctionName(configMock.deleteConfig), "some-dir").Return(nil)
+
+				installConfigMock := &myMock{}
+				installConfigMock.On(r.GetFunctionName(installConfigMock.Load), kind, cmd.Flags()).Return(config, nil)
+
+				prereqErrorLine := "[PREREQ-FAILED] random check fails"
+				executorMock := &myMock{}
+				executorMock.On(r.GetFunctionName(executorMock.ExecutePs), testCmd, powershell.PowerShellV5, mock.AnythingOfType("*common.OutputWriter")).Return(expectedError).Run(func(args mock.Arguments) {
+					ow := args.Get(2).(*common.OutputWriter)
+					ow.WriteErr(prereqErrorLine)
+				})
+
+				sut := &core.Installer{
+					Printer:             printerMock,
+					InstallConfigAccess: installConfigMock,
+					ExecutePsScript:     executorMock.ExecutePs,
+					GetVersionFunc:      func() version.Version { return version.Version{} },
+					GetPlatformFunc:     func() string { return "test-os" },
+					GetInstallDirFunc:   func() string { return "test-dir" },
+					LoadConfigFunc:      configMock.loadConfig,
+					DeleteConfigFunc:    configMock.deleteConfig,
+				}
+
+				err := sut.Install(kind, cmd, buildCmdFunc)
+
+				Expect(err).To(BeNil())
 			})
 		})
 

--- a/k2s/cmd/k2s/cmd/install/install.go
+++ b/k2s/cmd/k2s/cmd/install/install.go
@@ -90,6 +90,7 @@ func init() {
 		PrintCompletedMessageFunc: common.PrintCompletedMessage,
 		LoadConfigFunc:            setupinfo.ReadConfig,
 		SetConfigFunc:             setupinfo.WriteConfig,
+		DeleteConfigFunc:          setupinfo.DeleteConfig,
 	}
 
 	multivm.Installer = installer


### PR DESCRIPTION
There are two categories of failures during install
1. Pre-requisites failure ---> does not lead to corrupted state, uninstall is not necessary, cleanup of setup.json done.
2. Installation failure --> leads to corrupted state, uninstall is required.