### PR TITLE
feat(uninstall): default uninstall when setup is invalid

### DIFF
--- a/k2s/cmd/k2s/cmd/uninstall/uninstall.go
+++ b/k2s/cmd/k2s/cmd/uninstall/uninstall.go
@@ -111,7 +111,9 @@ func buildUninstallCmd(flags *pflag.FlagSet, setupName setupinfo.SetupName) (str
 	case setupinfo.SetupNameMultiVMK8s:
 		cmd = buildMultiVMUninstallCmd(skipPurgeFlag, outputFlag, additionalHooksDir, deleteFilesForOfflineInstallation)
 	default:
-		return "", errors.New("could not determine the setup type, aborting. If you are sure you have a K2s setup installed, call the correct uninstall script directly")
+		slog.Warn("Uninstall", "Found invalid setup type", string(setupName))
+		pterm.Warning.Printfln("could not determine the setup type, proceeding uninstall with default variant 'k2s'")
+		cmd = buildk2sUninstallCmd(skipPurgeFlag, outputFlag, additionalHooksDir, deleteFilesForOfflineInstallation)
 	}
 
 	return cmd, nil


### PR DESCRIPTION
This handles scenario when setuptype is invalid then proceed with default variant 'k2s' uninstall which cleans up the invalid setup.json as well. Then user is not blocked with install and uninstall cycle.