### PR TITLE
Zscaler provision node certificate installation

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/provisioning.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/provisioning.module.psm1
@@ -228,6 +228,13 @@ function New-KubemasterBaseImage {
         (Invoke-CmdOnControlPlaneViaUserAndPwd "echo mtu 1400 | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
         (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo rm -f /etc/network/interfaces.d/50-cloud-init" -RemoteUser $remoteUser1).Output | Write-Log
 
+        Write-Log "Copying ZScaler Root CA certificate to kubemaster_in_provisioning node"
+        $Provisioning_Node_IPAddress = Get-VmIpForProvisioningKubeNode
+        Copy-ToRemoteComputerViaUserAndPwd -Source "$(Get-KubePath)\smallsetup\certificate\ZScalerRootCA.crt" -Target "/tmp/ZScalerRootCA.crt" -IpAddress $Provisioning_Node_IPAddress            
+       (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo mv /tmp/ZScalerRootCA.crt /usr/local/share/ca-certificates/" -RemoteUser $remoteUser1 ).Output | Write-Log
+       (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo update-ca-certificates" -RemoteUser $remoteUser1 ).Output | Write-Log         
+        Write-Log "Zscaler certificate added to CA certificates of kubemaster_in_provisioning node"        
+
         # ssh keys
         (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo rm -f /etc/ssh/ssh_host_*; sudo ssh-keygen -A; sudo systemctl restart ssh" -RemoteUser $remoteUser1).Output | Write-Log
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -116,6 +116,13 @@ Function Install-KubernetesArtifacts {
         }
     }
 
+    Write-Log "Copying ZScaler Root CA certificate to kubenode_in_provisioning VM"
+    $Provisioning_Node_IPAddress = Get-VmIpForProvisioningKubeNode
+    Copy-ToRemoteComputerViaUserAndPwd -Source "$(Get-KubePath)\smallsetup\certificate\ZScalerRootCA.crt" -Target "/tmp/ZScalerRootCA.crt" -IpAddress $Provisioning_Node_IPAddress            
+    &$executeRemoteCommand "sudo mv /tmp/ZScalerRootCA.crt /usr/local/share/ca-certificates/"
+    &$executeRemoteCommand "sudo update-ca-certificates"       
+    Write-Log "Zscaler certificate added to CA certificates of kubenode_in_provisioning VM"        
+
     Write-Log 'Configure bridged traffic'
     &$executeRemoteCommand 'echo overlay | sudo tee /etc/modules-load.d/k8s.conf' 
     &$executeRemoteCommand 'echo br_netfilter | sudo tee /etc/modules-load.d/k8s.conf' 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Install Zscaler certificate to KubeNode_IN_Provisioning VM

### Motivation

To avoid getting errors during image pull

### Modifications

Made changes to Common-setup.module.psm1 file.

### Verification

Verified locally that the certificate is getting added to "KubeNode_In_Provisioning" VM.

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->