### PR TITLE
Adding Zscaler cert to provisioning VM : Issue #630

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -115,6 +115,13 @@ Function Install-KubernetesArtifacts {
             (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $command -RemoteUser "$remoteUser" -RemoteUserPwd "$remoteUserPwd" -Retries $Retries -RepairCmd $RepairCmd).Output | Write-Log
         }
     }
+    
+    Write-Log "Copying ZScaler Root CA certificate to kubenode_in_provisioning VM"
+    $Provisioning_Node_IPAddress = Get-VmIpForProvisioningKubeNode
+    Copy-ToRemoteComputerViaUserAndPwd -Source "$(Get-KubePath)\lib\modules\k2s\k2s.node.module\linuxnode\setup\certificate\ZScalerRootCA.crt" -Target "/tmp/ZScalerRootCA.crt" -IpAddress $Provisioning_Node_IPAddress            
+    &$executeRemoteCommand "sudo mv /tmp/ZScalerRootCA.crt /usr/local/share/ca-certificates/"
+    &$executeRemoteCommand "sudo update-ca-certificates"       
+    Write-Log "Zscaler certificate added to CA certificates of kubenode_in_provisioning VM" 
 
     Write-Log 'Configure bridged traffic'
     &$executeRemoteCommand 'echo overlay | sudo tee /etc/modules-load.d/k8s.conf' 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -116,12 +116,12 @@ Function Install-KubernetesArtifacts {
         }
     }
     
-    Write-Log "Copying ZScaler Root CA certificate to kubenode_in_provisioning VM"
+    Write-Log "Copying ZScaler Root CA certificate to KUBENODE_IN_PROVISIONING VM"
     $Provisioning_Node_IPAddress = Get-VmIpForProvisioningKubeNode
     Copy-ToRemoteComputerViaUserAndPwd -Source "$(Get-KubePath)\lib\modules\k2s\k2s.node.module\linuxnode\setup\certificate\ZScalerRootCA.crt" -Target "/tmp/ZScalerRootCA.crt" -IpAddress $Provisioning_Node_IPAddress            
     &$executeRemoteCommand "sudo mv /tmp/ZScalerRootCA.crt /usr/local/share/ca-certificates/"
     &$executeRemoteCommand "sudo update-ca-certificates"       
-    Write-Log "Zscaler certificate added to CA certificates of kubenode_in_provisioning VM" 
+    Write-Log "Zscaler certificate added to CA certificates of KUBENODE_IN_PROVISIONING VM" 
 
     Write-Log 'Configure bridged traffic'
     &$executeRemoteCommand 'echo overlay | sudo tee /etc/modules-load.d/k8s.conf' 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
@@ -87,13 +87,6 @@ function New-ControlPlaneNodeOnNewVM {
     Copy-LocalPublicSshKeyToRemoteComputer -UserName $(Get-DefaultUserNameControlPlane) -UserPwd $(Get-DefaultUserPwdControlPlane) -IpAddress $($controlPlaneParams.IpAddress)
     Wait-ForSSHConnectionToLinuxVMViaSshKey
 
-    Write-Log "Copying ZScaler Root CA certificate to master node"
-    Copy-ToControlPlaneViaUserAndPwd  -Source "$(Get-KubePath)\lib\modules\k2s\k2s.node.module\linuxnode\setup\certificate\ZScalerRootCA.crt" -Target "/tmp/ZScalerRootCA.crt"
-    Remove-ControlPlaneAccessViaUserAndPwd
-    (Invoke-CmdOnControlPlaneViaSSHKey "sudo mv /tmp/ZScalerRootCA.crt /usr/local/share/ca-certificates/" ).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaSSHKey "sudo update-ca-certificates").Output | Write-Log
-    Write-Log "Zscaler certificate added to CA certificates of master node"
-
     # add kubectl to Windows host
     Install-KubectlTool
     # copy kubectl config file into Windows host


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Install Zscaler certificate on first VM that we create during the installation of K2s

### Motivation

To avoid failures while downloading the needed images.

### Modifications

Made changes in "Install-KubernetesArtifacts" of "common-setup.module.psm1" to install the Zscaler certificate.
Removed changes from "New-ControlPlaneNodeOnNewVM" of "control-plane-node.module.psm1" that installed the Zscaler certificate directly on KubeMaster.

### Verification

1.Tested by installing the K2s locally and made sure that the certificate is installed in Kubemaster. 
2. Also the installation of k2s with Debian 12 OS went through when Zscaler was enabled.

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->