### PR TITLE
fix(docker): consistent config across container runtimes

### DIFF
--- a/lib/modules/k2s/k2s.node.module/windowsnode/downloader/artifacts/docker/docker.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/windowsnode/downloader/artifacts/docker/docker.module.psm1
@@ -75,14 +75,6 @@ function Install-WinDocker {
         Stop-Service docker
     }
 
-    $dockerConfigDir = Get-ConfiguredDockerConfigDir
-
-
-    if (Test-Path $dockerConfigDir) {
-        $newName = $dockerConfigDir + '_' + $( Get-Date -Format yyyy-MM-dd_HHmmss )
-        Write-Log ("Saving: $dockerConfigDir to $newName")
-        Rename-Item $dockerConfigDir -NewName $newName
-    }
 
     # Register the Docker daemon as a service.
     $serviceName = 'docker'


### PR DESCRIPTION
Removed renaming of docker config as this operation conflicts with nerdctl login. Also, docker install is ad-hoc, so changing config at this point will lead to inconsistent configs.