### PR TITLE
fix(wsl): provide default value

### DIFF
--- a/lib/modules/k2s/k2s.infra.module/config/config.module.psm1
+++ b/lib/modules/k2s/k2s.infra.module/config/config.module.psm1
@@ -341,7 +341,11 @@ function Set-ConfigSetupType {
 }
 
 function Get-ConfigWslFlag {
-    return Get-ConfigValue -Path $SetupJsonFile -Key 'WSL'
+    $wslValue = Get-ConfigValue -Path $SetupJsonFile -Key 'WSL'
+    if ($null -eq $wslValue){
+        return $false
+    }
+    return $wslValue
 }
 
 function Get-ReuseExistingLinuxComputerForMasterNodeFlag {


### PR DESCRIPTION
Provide default value when config is not set. Without default value, observed errors during start and stop of the cluster and leads to inconsistent state.