### PR TITLE
fix(uninstall): falls back to default variant

### DIFF
--- a/k2s/cmd/k2s/cmd/uninstall/uninstall.go
+++ b/k2s/cmd/k2s/cmd/uninstall/uninstall.go
@@ -110,7 +110,9 @@ func buildUninstallCmd(flags *pflag.FlagSet, setupName setupinfo.SetupName) (str
 	case setupinfo.SetupNameMultiVMK8s:
 		cmd = buildMultiVMUninstallCmd(skipPurgeFlag, outputFlag, additionalHooksDir, deleteFilesForOfflineInstallation)
 	default:
-		return "", errors.New("could not determine the setup type, aborting. If you are sure you have a K2s setup installed, call the correct uninstall script directly")
+		slog.Warn("Uninstall", "Found invalid setup type", string(setupName))
+		pterm.Warning.Printfln("could not determine the setup type, proceeding uninstall with default variant 'k2s'")
+		cmd = buildk2sUninstallCmd(skipPurgeFlag, outputFlag, additionalHooksDir, deleteFilesForOfflineInstallation)
 	}
 
 	return cmd, nil


### PR DESCRIPTION
#796
Merges the changes from #506 for falling back to the 'default variant' setup type in case the setup type cannot be determined during uninstallation.