### PR TITLE
fix: add all k2s hosts during install

### DIFF
--- a/lib/modules/k2s/k2s.node.module/windowsnode/system/system.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/windowsnode/system/system.module.psm1
@@ -100,30 +100,8 @@ function Enable-MissingWindowsFeatures($wsl) {
     In order to display the correct IP to be configured in the proxy settings, the GlobalVariables.ps1 file must be included in the calling script first.
 #>
 function Test-ProxyConfiguration() {
-    $ipControlPlane = Get-ConfiguredIPControlPlane
     if (($env:HTTP_Proxy).Length -eq 0 -and ($env:HTTPS_Proxy).Length -eq 0 ) {
         return
-    }
-
-    if (!$ipControlPlane) {
-        throw "The calling script must include the file 'GlobalVariables.ps1' first!"
-    }
-
-    if (($env:NO_Proxy).Length -eq 0) {
-        Write-Log 'You have configured proxies with environment variable HTTP_Proxy, but the NO_Proxy'
-        Write-Log 'is not set. You have to configure NO_Proxy in the system environment variables.'
-        Write-Log "NO_Proxy must be set to $ipControlPlane"
-        Write-Log "Don't change the variable in the current shell only, that will not work!"
-        Write-Log "After configuring the system environment variable, log out and log in!`n"
-        throw "NO_Proxy must contain $ipControlPlane"
-    }
-
-    if (! ($env:NO_Proxy | Select-String -Pattern "\b$ipControlPlane\b")) {
-        Write-Log 'You have configured proxies with environment variable HTTP_Proxy, but the NO_Proxy'
-        Write-Log "doesn't contain $ipControlPlane. You have to configure NO_Proxy in the system environment variables."
-        Write-Log "Don't change the variable in the current shell only, that will not work!"
-        Write-Log "After configuring the system environment variable, log out and log in!`n"
-        throw "NO_Proxy must contain $ipControlPlane"
     }
 }
 

--- a/smallsetup/common/GlobalFunctions.ps1
+++ b/smallsetup/common/GlobalFunctions.ps1
@@ -1224,27 +1224,6 @@ function Test-ProxyConfiguration() {
     if (($env:HTTP_Proxy).Length -eq 0 -and ($env:HTTPS_Proxy).Length -eq 0 ) {
         return
     }
-
-    if (!$global:IP_Master) {
-        throw "The calling script must include the file 'GlobalVariables.ps1' first!"
-    }
-
-    if (($env:NO_Proxy).Length -eq 0) {
-        Write-Log 'You have configured proxies with environment variable HTTP_Proxy, but the NO_Proxy'
-        Write-Log 'is not set. You have to configure NO_Proxy in the system environment variables.'
-        Write-Log "NO_Proxy must be set to $global:IP_Master"
-        Write-Log "Don't change the variable in the current shell only, that will not work!"
-        Write-Log "After configuring the system environment variable, log out and log in!`n"
-        throw "NO_Proxy must contain $global:IP_Master"
-    }
-
-    if (! ($env:NO_Proxy | Select-String -Pattern "\b$global:IP_Master\b")) {
-        Write-Log 'You have configured proxies with environment variable HTTP_Proxy, but the NO_Proxy'
-        Write-Log "doesn't contain $global:IP_Master. You have to configure NO_Proxy in the system environment variables."
-        Write-Log "Don't change the variable in the current shell only, that will not work!"
-        Write-Log "After configuring the system environment variable, log out and log in!`n"
-        throw "NO_Proxy must contain $global:IP_Master"
-    }
 }
 
 <#

--- a/smallsetup/ps-modules/proxy/proxy.module.psm1
+++ b/smallsetup/ps-modules/proxy/proxy.module.psm1
@@ -2,6 +2,15 @@
 #
 # SPDX-License-Identifier: MIT
 
+
+function Get-K2sHosts() {
+    $clusterServicesCidr = $global:ClusterCIDR_Services
+    $clusterCidr = $global:ClusterCIDR
+    $ipControlPlaneCidr = $global:IP_CIDR
+
+    return @($clusterServicesCidr, $clusterCidr, $ipControlPlaneCidr, "local", "svc.cluster.local")
+}
+
 <#
 .SYNOPSIS
 Gets whether proxy settings are configured for the user in Windows.
@@ -77,21 +86,32 @@ function Get-OrUpdateProxyServer ([string]$Proxy) {
     }
     return $Proxy
 }
-
 function Add-K2sHostsToNoProxyEnvVar() {
     $noProxyEnvVar = [Environment]::GetEnvironmentVariable("NO_PROXY", "Machine")
+    $k2sHosts = Get-K2sHosts
+
     if (![string]::IsNullOrWhiteSpace($noProxyEnvVar)) {
-        $noProxyEnvVar += ",local"
-        [Environment]::SetEnvironmentVariable("NO_PROXY", $noProxyEnvVar, "Machine")
+        $noProxyList = $noProxyEnvVar -split ","
+    } else {
+        $noProxyList = @()
     }
+
+    $noProxyList += $k2sHosts
+    $noProxyList = $noProxyList | Sort-Object -Unique
+    $updatedNoProxyEnvVar = $noProxyList -join ","
+    [Environment]::SetEnvironmentVariable("NO_PROXY", $updatedNoProxyEnvVar, "Process")
+    [Environment]::SetEnvironmentVariable("NO_PROXY", $updatedNoProxyEnvVar, "Machine")
 }
 
 function Remove-K2sHostsFromNoProxyEnvVar() {
     $noProxyEnvVar = [Environment]::GetEnvironmentVariable("NO_PROXY", "Machine")
+    $k2sHosts = Get-K2sHosts
+
     if (![string]::IsNullOrWhiteSpace($noProxyEnvVar)) {
         $noProxyList = $noProxyEnvVar -split ","
-        $noProxyList = $noProxyList | Where-Object { $_ -ne "local" }
+        $noProxyList = $noProxyList | Where-Object { $_ -notin $k2sHosts }
         $updatedNoProxyEnvVar = $noProxyList -join ","
+        [Environment]::SetEnvironmentVariable("NO_PROXY", $updatedNoProxyEnvVar, "Process")
         [Environment]::SetEnvironmentVariable("NO_PROXY", $updatedNoProxyEnvVar, "Machine")
     }
 }


### PR DESCRIPTION
If NO_PROXY variable is set then all k2s subnets and hosts are added to it during installation. They are removed on uninstallation