### PR TITLE
feat(node): adds/removes Ubuntu bare metal node to/from the cluster

### DIFF
--- a/lib/modules/k2s/k2s.cluster.module/setup/setupcluster.module.psm1
+++ b/lib/modules/k2s/k2s.cluster.module/setup/setupcluster.module.psm1
@@ -305,6 +305,8 @@ function Remove-LinuxNode {
     (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo rm -rf /etc/kubernetes' -UserName $NodeUserName -IpAddress $NodeIpAddress).Output | Write-Log
     (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'echo y | sudo kubeadm reset' -UserName $NodeUserName -IpAddress $NodeIpAddress).Output | Write-Log
 
+    (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo rm -rf /etc/cni' -UserName $NodeUserName -IpAddress $NodeIpAddress).Output | Write-Log
+
     &$PostStepHook
 
 }

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -114,12 +114,18 @@ Function Install-KubernetesArtifacts {
         }
     }
     
-    Write-Log "Copying ZScaler Root CA certificate to KUBENODE_IN_PROVISIONING VM"
-    $Provisioning_Node_IPAddress = Get-VmIpForProvisioningKubeNode
-    Copy-ToRemoteComputerViaUserAndPwd -Source "$(Get-KubePath)\lib\modules\k2s\k2s.node.module\linuxnode\setup\certificate\ZScalerRootCA.crt" -Target "/tmp/ZScalerRootCA.crt" -IpAddress $Provisioning_Node_IPAddress            
+    Write-Log "Copying ZScaler Root CA certificate to computer with IP '$IpAddress'"
+    $zScalerCertificateSourcePath = "$(Get-KubePath)\lib\modules\k2s\k2s.node.module\linuxnode\setup\certificate\ZScalerRootCA.crt"
+    $zScalerCertificateTargetPath = "/tmp/ZScalerRootCA.crt"
+    if ([string]::IsNullOrWhiteSpace($UserPwd)) {
+        Copy-ToRemoteComputerViaSshKey -Source $zScalerCertificateSourcePath -Target $zScalerCertificateTargetPath -UserName $UserName -IpAddress $IpAddress
+    } else {
+        Copy-ToRemoteComputerViaUserAndPwd -Source $zScalerCertificateSourcePath -Target $zScalerCertificateTargetPath -UserName $UserName -UserPwd $UserPwd -IpAddress $IpAddress
+    }
+    
     &$executeRemoteCommand "sudo mv /tmp/ZScalerRootCA.crt /usr/local/share/ca-certificates/"
     &$executeRemoteCommand "sudo update-ca-certificates"       
-    Write-Log "Zscaler certificate added to CA certificates of KUBENODE_IN_PROVISIONING VM" 
+    Write-Log "Zscaler certificate added to CA certificates of computer with IP '$IpAddress'" 
 
     Write-Log 'Configure bridged traffic'
     &$executeRemoteCommand 'echo overlay | sudo tee /etc/modules-load.d/k8s.conf' 
@@ -264,7 +270,7 @@ Function Remove-KubernetesArtifacts {
 
     &$executeRemoteCommand 'sudo systemctl daemon-reload' 
 
-    &$executeRemoteCommand 'sudo apt-get remove --yes --allow-change-held-packages kubelet kubeadm kubectl' 
+    &$executeRemoteCommand 'sudo apt-get purge --yes --allow-change-held-packages kubelet kubeadm kubectl' 
 
     &$executeRemoteCommand 'sudo rm -f /etc/containers/registries.conf' 
     &$executeRemoteCommand 'sudo rm -f /etc/cni/net.d/100-crio-bridge.conf'
@@ -286,6 +292,9 @@ Function Remove-KubernetesArtifacts {
     &$executeRemoteCommand 'sudo rm -f /etc/sysctl.d/k8s.conf'
     &$executeRemoteCommand 'sudo rm -f /etc/modules-load.d/k8s.conf'
     &$executeRemoteCommand 'sudo sysctl --system'
+
+    &$executeRemoteCommand 'sudo apt-get purge --yes dnsmasq'
+    &$executeRemoteCommand 'sudo apt-get purge --yes cri-o'
 }
 
 <#
@@ -585,8 +594,10 @@ A script block that will get executed at the end of the set-up process (can be u
 Function Set-UpMasterNode {
     param (
         [ValidateScript({ !([string]::IsNullOrWhiteSpace($_)) })]
+        [string]$NodeName = $(throw 'Argument missing: NodeName'),
+        [ValidateScript({ !([string]::IsNullOrWhiteSpace($_)) })]
         [string]$UserName = $(throw 'Argument missing: UserName'),
-        [string]$UserPwd = $(throw 'Argument missing: UserPwd'),
+        [string]$UserPwd = '',
         [ValidateScript({ Get-IsValidIPv4Address($_) })]
         [string]$IpAddress = $(throw 'Argument missing: IpAddress'),
         [ValidateScript({ !([string]::IsNullOrWhiteSpace($_)) })]
@@ -601,8 +612,6 @@ Function Set-UpMasterNode {
         [string] $IP_NextHop = $(throw 'Argument missing: IP_NextHop'),
         [ValidateScript({ !([string]::IsNullOrWhiteSpace($_)) })]
         [string] $NetworkInterfaceName = $(throw 'Argument missing: NetworkInterfaceName'),
-        [ValidateScript({ Get-IsValidIPv4Address($_) })]
-        [string] $NetworkInterfaceCni0IP_Master = $(throw 'Argument missing: NetworkInterfaceCni0IP_Master'),
         [ScriptBlock] $Hook = $(throw 'Argument missing: Hook')
     )
 
@@ -614,11 +623,10 @@ Function Set-UpMasterNode {
             $command = $(throw 'Argument missing: Command'), 
             [switch]$IgnoreErrors = $false
         ) 
-        if ($IgnoreErrors) {
-            (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $command -RemoteUser "$remoteUser" -RemoteUserPwd "$remoteUserPwd" -IgnoreErrors).Output | Write-Log
-        }
-        else {
-            (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $command -RemoteUser "$remoteUser" -RemoteUserPwd "$remoteUserPwd").Output | Write-Log
+        if ([string]::IsNullOrWhiteSpace($remoteUserPwd)) {
+            (Invoke-CmdOnVmViaSSHKey -CmdToExecute $command -UserName $UserName -IpAddress $IpAddress -IgnoreErrors:$IgnoreErrors).Output | Write-Log
+        } else {
+            (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $command -RemoteUser "$remoteUser" -RemoteUserPwd "$remoteUserPwd" -IgnoreErrors:$IgnoreErrors).Output | Write-Log
         }
     }
 
@@ -648,10 +656,6 @@ Function Set-UpMasterNode {
     Write-Log 'Restart custom DNS server'
     &$executeRemoteCommand 'sudo systemctl restart dnsmasq' 
 
-    Write-Log 'Add DNS resolution rules to K8s DNS component'
-    # change config map to forward all non cluster DNS request to proxy (dnsmasq) running on master
-    &$executeRemoteCommand "kubectl get configmap/coredns -n kube-system -o yaml | sed -e 's|forward . /etc/resolv.conf|forward . $NetworkInterfaceCni0IP_Master|' | kubectl apply -f -" -IgnoreErrors
-    
     # import etcd certificates as k8s secrets, so that coredns can access etcd
     &$executeRemoteCommand 'sudo mkdir etcd'
     &$executeRemoteCommand 'sudo cp /etc/kubernetes/pki/etcd/* etcd/'
@@ -676,6 +680,19 @@ Function Set-UpMasterNode {
     Write-Log 'Initialize Flannel'
     Add-FlannelPluginToMasterNode -IpAddress $IpAddress -UserName $UserName -UserPwd $UserPwd -PodNetworkCIDR $ClusterCIDR
 
+    $getPodCidrOutput = Get-AssignedPodNetworkCIDR -NodeName $NodeName -UserName $UserName -UserPwd $UserPwd -IpAddress $IpAddress
+    if ($getPodCidrOutput.Success) {
+        $assignedPodNetworkCIDR = $($getPodCidrOutput.PodNetworkCIDR).Substring(0, $($getPodCidrOutput.PodNetworkCIDR).IndexOf('/'))
+    } else {
+        throw "Cannot obtain pod network information from node '$NodeName'"
+    }
+    $networkInterfaceCni0IP = "$($assignedPodNetworkCIDR.Substring(0, $assignedPodNetworkCIDR.lastIndexOf('.'))).1"
+
+    Write-Log 'Add DNS resolution rules to K8s DNS component'
+    # change config map to forward all non cluster DNS request to proxy (dnsmasq) running on master
+    &$executeRemoteCommand "kubectl get configmap/coredns -n kube-system -o yaml | sed -e 's|forward . /etc/resolv.conf|forward . $networkInterfaceCni0IP|' | kubectl apply -f -" -IgnoreErrors
+
+
     Write-Log 'Run setup hook'
     &$Hook
     Write-Log 'Setup hook finished'
@@ -685,7 +702,6 @@ Function Set-UpMasterNode {
     &$executeRemoteCommand "echo 'nameserver 127.0.0.1' | sudo tee /etc/resolv.conf" 
 
     Write-Log 'Finished setting up Linux computer as master'
-
 }
 
 Function Set-UpWorkerNode {
@@ -727,7 +743,7 @@ Function Add-FlannelPluginToMasterNode {
     param (
         [ValidateScript({ !([string]::IsNullOrWhiteSpace($_)) })]
         [string]$UserName = $(throw 'Argument missing: UserName'),
-        [string]$UserPwd = $(throw 'Argument missing: UserPwd'),
+        [string]$UserPwd = '',
         [ValidateScript({ Get-IsValidIPv4Address($_) })]
         [string]$IpAddress = $(throw 'Argument missing: IpAddress'),
         [ValidateScript({ !([string]::IsNullOrWhiteSpace($_)) })]
@@ -740,7 +756,11 @@ Function Add-FlannelPluginToMasterNode {
     $fileName = 'flannel.yml'
 
     $executeRemoteCommand = { param($command = $(throw 'Argument missing: Command')) 
-    (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $command -RemoteUser "$remoteUser" -RemoteUserPwd "$remoteUserPwd").Output | Write-Log
+        if ([string]::IsNullOrWhiteSpace($remoteUserPwd)) {
+            (Invoke-CmdOnVmViaSSHKey -CmdToExecute $command -UserName $UserName -IpAddress $IpAddress -IgnoreErrors:$IgnoreErrors).Output | Write-Log
+        } else {
+            (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $command -RemoteUser "$remoteUser" -RemoteUserPwd "$remoteUserPwd").Output | Write-Log
+        }
     }
 
     $waitUntilContainerNetworkPluginIsRunning = { 
@@ -748,7 +768,12 @@ Function Add-FlannelPluginToMasterNode {
         while ($true) {
             $iteration++
             # try to apply the flannel resources
-            $result = (Invoke-CmdOnControlPlaneViaUserAndPwd 'kubectl rollout status daemonset -n kube-flannel kube-flannel-ds --timeout 60s' -RemoteUser "$remoteUser" -RemoteUserPwd "$remoteUserPwd").Output
+            $command = 'kubectl rollout status daemonset -n kube-flannel kube-flannel-ds --timeout 60s'
+            if ([string]::IsNullOrWhiteSpace($remoteUserPwd)) {
+                $result = (Invoke-CmdOnVmViaSSHKey -CmdToExecute $command -UserName $UserName -IpAddress $IpAddress -IgnoreErrors:$IgnoreErrors).Output
+            } else {
+                $result = (Invoke-CmdOnControlPlaneViaUserAndPwd $command -RemoteUser "$remoteUser" -RemoteUserPwd "$remoteUserPwd").Output
+            }
             if ($result -match 'successfully') {
                 break;
             } 
@@ -801,7 +826,11 @@ Function Add-FlannelPluginToMasterNode {
     }
     Write-Log 'Copy Flannel configuration file to computer'
     $target = "/home/$UserName"
-    Copy-ToControlPlaneViaUserAndPwd -Source "$configurationFile" -Target $target
+    if ([string]::IsNullOrWhiteSpace($remoteUserPwd)) {
+        Copy-ToRemoteComputerViaSshKey -Source "$configurationFile" -Target $target -UserName $UserName -IpAddress $IpAddress
+    } else {
+        Copy-ToRemoteComputerViaUserAndPwd -Source "$configurationFile" -Target $target -UserName $UserName -UserPwd $remoteUserPwd -IpAddress $IpAddress
+    }
 
     Write-Log 'Apply flannel configuration file on computer'
     &$executeRemoteCommand "kubectl apply -f ~/$fileName" 
@@ -975,6 +1004,7 @@ function New-VmImageForControlPlaneNode {
         }
 
         $masterNodeParams = @{
+            NodeName                      = $Hostname
             IpAddress                     = $IpAddress
             UserName                      = $vmUserName
             UserPwd                       = $vmUserPwd
@@ -984,7 +1014,6 @@ function New-VmImageForControlPlaneNode {
             KubeDnsServiceIP              = $(Get-ConfiguredKubeDnsServiceIP)
             IP_NextHop                    = $GatewayIpAddress
             NetworkInterfaceName          = $vmNetworkInterfaceName
-            NetworkInterfaceCni0IP_Master = $(Get-ConfiguredMasterNetworkInterfaceCni0IP)
             Hook                          = $addToControlPlane
         }
         Set-UpMasterNode @masterNodeParams 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/worker-node.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/worker-node.module.psm1
@@ -268,6 +268,115 @@ function Stop-LinuxWorkerNodeOnExistingVM {
     }
 }
 
+function Add-LinuxWorkerNodeOnUbuntuBareMetal {
+    Param(
+        [string] $NodeName = $(throw 'Argument missing: NodeName'),
+        [string] $UserName = $(throw 'Argument missing: UserName'),
+        [string] $IpAddress = $(throw 'Argument missing: IpAddress'),
+        [string] $WindowsHostIpAddress = $(throw 'Argument missing: WindowsHostIpAddress'),
+        [string] $Proxy = '',
+        [string] $AdditionalHooksDir = ''
+    )
+
+    $k8sVersion = Get-DefaultK8sVersion
+    Install-KubernetesArtifacts -UserName $UserName -IpAddress $IpAddress -K8sVersion $k8sVersion -Proxy $Proxy
+    
+    Write-Log " Add firewall rules for Kubernetes"
+    (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo ufw allow 6443/tcp' -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+    (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo ufw allow 2379:2380/tcp' -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+    (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo ufw allow 10250/tcp' -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+    (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo ufw allow 10259/tcp' -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+    (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo ufw allow 10257/tcp' -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+    (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo ufw allow 9153/tcp' -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+    
+    $doBeforeJoining = {
+        # add a route to the cluster network over the Windows host IP address
+        $controlPlaneCIDR = Get-ConfiguredControlPlaneCIDR
+        (Invoke-CmdOnVmViaSSHKey -CmdToExecute "sudo ip route add $controlPlaneCIDR via $WindowsHostIpAddress" -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+
+        $podNetworkCIDR = Get-ConfiguredClusterCIDR
+        (Invoke-CmdOnVmViaSSHKey -CmdToExecute "sudo ip route add $podNetworkCIDR via $WindowsHostIpAddress" -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+
+        $networkInterfaceName = (Get-NetIPAddress | Where-Object { $_.AddressFamily -eq "IPv4" -and ($_.IPAddress -match $WindowsHostIpAddress)} | Select-Object -ExpandProperty InterfaceAlias)
+        if ([string]::IsNullOrWhiteSpace($networkInterfaceName)) {
+            throw "Cannot find the network interface belonging to the IP address '$WindowsHostIpAddress'"
+        }
+
+        netsh int ipv4 set int $networkInterfaceName forwarding=enabled | Out-Null 
+    }
+
+    $k8sFormattedNodeName = $NodeName.ToLower()
+    Join-LinuxNode -NodeName $k8sFormattedNodeName.ToLower() -NodeUserName $UserName -NodeIpAddress $IpAddress -PreStepHook $doBeforeJoining
+}
+
+function Remove-LinuxWorkerNodeOnUbuntuBareMetal {
+    Param(
+        [string] $NodeName = $(throw 'Argument missing: NodeName'),
+        [string] $UserName = $(throw 'Argument missing: UserName'),
+        [string] $IpAddress = $(throw 'Argument missing: IpAddress'),
+        [string] $AdditionalHooksDir = '',
+        [switch] $SkipHeaderDisplay = $false
+    )
+
+    if ($SkipHeaderDisplay -eq $false) {
+        Write-Log "Removing K2s worker node '$NodeName'"
+    }
+
+    $doAfterRemoving = {
+        # delete routes
+        $controlPlaneCIDR = Get-ConfiguredControlPlaneCIDR
+        (Invoke-CmdOnVmViaSSHKey -CmdToExecute "sudo ip route delete $controlPlaneCIDR" -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+
+        $podNetworkCIDR = Get-ConfiguredClusterCIDR
+        (Invoke-CmdOnVmViaSSHKey -CmdToExecute "sudo ip route delete $podNetworkCIDR" -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+        
+        # delete network interface 'cni0' that was created by flannel
+        (Invoke-CmdOnVmViaSSHKey -CmdToExecute "sudo ip link delete cni0" -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+    }
+
+    $k8sFormattedNodeName = $NodeName.ToLower()
+    $clusterState = (Invoke-Kubectl -Params @('get', 'nodes', '-o', 'wide')).Output
+    if ($clusterState -match $k8sFormattedNodeName) {
+        Remove-LinuxNode -NodeName $k8sFormattedNodeName -NodeUserName $UserName -NodeIpAddress $IpAddress -PostStepHook $doAfterRemoving
+    }
+
+    Remove-KubernetesArtifacts -UserName $UserName -IpAddress $IpAddress
+
+    if ($SkipHeaderDisplay -eq $false) {
+        Write-Log "Removing K2s worker node '$NodeName' done."
+    }
+}
+
+function Start-LinuxWorkerNodeOnUbuntuBareMetal {
+    Param(
+        [string] $IpAddress = $(throw 'Argument missing: IpAddress'),
+        [string] $NodeName = $(throw 'Argument missing: NodeName'),
+        [string] $AdditionalHooksDir = '',
+        [switch] $SkipHeaderDisplay = $false
+    )
+
+    Add-RouteToLinuxWorkerNode -NodeName $NodeName -IpAddress $IpAddress
+
+    if ($SkipHeaderDisplay -eq $false) {
+        Write-Log "K2s worker node '$NodeName' started"
+    }
+}
+
+function Stop-LinuxWorkerNodeOnUbuntuBareMetal {
+    Param(
+        [string] $NodeName = $(throw 'Argument missing: NodeName'),
+        [string] $AdditionalHooksDir = '',
+        [switch] $SkipHeaderDisplay = $false
+
+    )
+
+    Remove-RouteToLinuxWorkerNode -NodeName $NodeName
+    
+    if ($SkipHeaderDisplay -eq $false) {
+        Write-Log "K2s worker node '$NodeName' stopped"
+    }
+}
+
 function Add-RouteToLinuxWorkerNode {
     Param(
         [string] $IpAddress = $(throw 'Argument missing: IpAddress'),
@@ -288,7 +397,7 @@ function Add-RouteToLinuxWorkerNode {
         Write-Log "Add route to $clusterCIDRWorker"
         route -p add $clusterCIDRWorker $IpAddress METRIC 4 | Out-Null
     } else {
-        throw "Cannot obtain container network information from node '$NodeName'"
+        throw "Cannot obtain pod network information from node '$NodeName'"
     }
 }
 
@@ -310,7 +419,7 @@ function Remove-RouteToLinuxWorkerNode {
         Write-Log "Remove obsolete route to $clusterCIDRWorker"
         route delete $clusterCIDRWorker >$null 2>&1
     } else {
-        Write-Log "Cannot obtain container network information from node '$NodeName'. The eventually existing routes belonging to this node will not be deleted."
+        Write-Log "Cannot obtain pod network information from node '$NodeName'. The eventually existing routes belonging to this node will not be deleted."
     }
 }
 
@@ -321,4 +430,8 @@ Remove-LinuxWorkerNodeOnNewVM,
 Start-LinuxWorkerNodeOnExistingVM,
 Stop-LinuxWorkerNodeOnExistingVM,
 Add-LinuxWorkerNodeOnExistingUbuntuVM,
-Remove-LinuxWorkerNodeOnExistingUbuntuVM
+Remove-LinuxWorkerNodeOnExistingUbuntuVM,
+Add-LinuxWorkerNodeOnUbuntuBareMetal,
+Remove-LinuxWorkerNodeOnUbuntuBareMetal,
+Start-LinuxWorkerNodeOnUbuntuBareMetal,
+Stop-LinuxWorkerNodeOnUbuntuBareMetal

--- a/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
@@ -343,10 +343,14 @@ function Copy-ToControlPlaneViaUserAndPwd($Source, $Target,
 
 function Copy-ToRemoteComputerViaUserAndPwd($Source, $Target, $IpAddress,
     [Parameter(Mandatory = $false)]
+    [string]$UserName = $defaultUserName,
+    [Parameter(Mandatory = $false)]
+    [string]$UserPwd = $remotePwd,
+    [Parameter(Mandatory = $false)]
     [switch]$IgnoreErrors = $false) {
     Write-Log "Copying '$Source' to '$Target', ignoring errors: '$IgnoreErrors'"
 
-    $output = Write-Output yes | &"$scpExe" -ssh -4 -q -r -pw $remotePwd "$Source" "${defaultUserName}@${IpAddress}:$Target" 2>&1
+    $output = Write-Output yes | &"$scpExe" -ssh -4 -q -r -pw $UserPwd "$Source" "${UserName}@${IpAddress}:$Target" 2>&1
 
     if ($LASTEXITCODE -ne 0 -and !$IgnoreErrors) {
         throw "Could not copy '$Source' to '$Target': $output"

--- a/lib/scripts/worker-node/linux/bare-metal/Add.ps1
+++ b/lib/scripts/worker-node/linux/bare-metal/Add.ps1
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
+#
+# SPDX-License-Identifier: MIT
+
+#Requires -RunAsAdministrator
+
+Param(
+    [string] $NodeName = $(throw 'Argument missing: NodeName'),
+    [string] $UserName = $(throw 'Argument missing: UserName'),
+    [string] $IpAddress = $(throw 'Argument missing: IpAddress'),
+    [string] $WindowsHostIpAddress = $(throw 'Argument missing: WindowsHostIpAddress'),
+    [string] $Proxy = '',
+    [switch] $ShowLogs = $false
+)
+
+$durationStopwatch = [system.diagnostics.stopwatch]::StartNew()
+
+$infraModule =   "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.infra.module\k2s.infra.module.psm1"
+$nodeModule =    "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.node.module\k2s.node.module.psm1"
+$clusterModule = "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.cluster.module\k2s.cluster.module.psm1"
+Import-Module $infraModule, $nodeModule, $clusterModule
+
+Initialize-Logging -ShowLogs:$ShowLogs
+
+$ErrorActionPreference = 'Stop'
+
+# make sure we are at the right place for install
+$installationPath = Get-KubePath
+Set-Location $installationPath
+
+# check if the computer is already part of the cluster
+$k8sFormattedNodeName = $NodeName.ToLower()
+$clusterState = (Invoke-Kubectl -Params @('get', 'nodes', '-o', 'wide')).Output
+if ($clusterState -match $k8sFormattedNodeName) {
+    throw "Precondition not met: the node '$k8sFormattedNodeName' is not part of the cluster."
+}
+
+$connectionCheck = (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'which ls' -UserName $UserName -IpAddress $IpAddress)
+if (!$connectionCheck.Success) {
+    throw "Cannot connect to node with IP '$IpAddress'. Error message: $($connectionCheck.Output)"
+}
+
+# check if the authorized public key in the computer is the same as the one in the Windows Host
+$localPublicKeyFilePath = "$(Get-SSHKeyControlPlane).pub"
+if (!(Test-Path -Path $localPublicKeyFilePath)) {
+    throw "Precondition not met: the file '$localPublicKeyFilePath' shall exist."
+}
+$localPublicKey = (Get-Content -Raw $localPublicKeyFilePath).Trim()
+if ([string]::IsNullOrWhiteSpace($localPublicKey)) {
+    throw "Precondition not met: the file '$localPublicKeyFilePath' is not empty."
+}
+$authorizedKeysFilePath = '~/.ssh/authorized_keys'
+$authorizedKeys = (Invoke-CmdOnVmViaSSHKey -CmdToExecute "[ -f $authorizedKeysFilePath ] && cat $authorizedKeysFilePath || echo 'File $authorizedKeysFilePath not available'" -UserName $UserName -IpAddress $IpAddress).Output
+if (!($authorizedKeys.Contains($localPublicKey))) {
+    throw "Precondition not met: the local public key from the file '$localPublicKeyFilePath' is present in the file '$authorizedKeysFilePath' of the computer with IP '$IpAddress'."
+}
+
+# check if the intended node name to add to the cluster is the same as the hostname of the computer behind the passed IP address
+$actualHostname = (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'echo $(hostname)' -UserName $UserName -IpAddress $IpAddress).Output
+if ($k8sFormattedNodeName -ne $actualHostname.ToLower()) {
+    throw "Precondition not met: the passed NodeName '$NodeName' is the hostname of the computer with IP '$IpAddress' ($actualHostname)"
+}
+
+Write-Log "Disable swap"
+(Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo swapon --show' -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+(Invoke-CmdOnVmViaSSHKey -CmdToExecute "swapFiles=`$(cat /proc/swaps | awk 'NR>1 {print `$1}')" -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+(Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo swapoff -a' -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+(Invoke-CmdOnVmViaSSHKey -CmdToExecute "for swapFile in `$swapFiles; do sudo rm '`$swapFile'; done" -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+(Invoke-CmdOnVmViaSSHKey -CmdToExecute "sudo sed -i '/\sswap\s/d' /etc/fstab" -UserName $UserName -IpAddress $IpAddress).Output | Write-Log
+
+$workerNodeParams = @{
+    NodeName = $NodeName
+    UserName = $UserName
+    IpAddress = $IpAddress
+    WindowsHostIpAddress = $WindowsHostIpAddress
+    Proxy = $Proxy
+    AdditionalHooksDir = $AdditionalHooksDir
+}
+Add-LinuxWorkerNodeOnUbuntuBareMetal @workerNodeParams
+
+if (! $SkipStart) {
+    Write-Log 'Starting worker node'
+    & "$PSScriptRoot\Start.ps1" -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay -IpAddress $IpAddress -NodeName $NodeName
+
+    if ($RestartAfterInstallCount -gt 0) {
+        $restartCount = 0;
+    
+        while ($true) {
+            $restartCount++
+            Write-Log "Restarting worker (iteration #$restartCount):"
+    
+            & "$PSScriptRoot\Stop.ps1" -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay -NodeName $NodeName
+            Start-Sleep 10
+    
+            & "$PSScriptRoot\Start.ps1" -AdditionalHooksDir:$AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay -IpAddress $IpAddress -NodeName $NodeName
+            Start-Sleep -s 5
+    
+            if ($restartCount -eq $RestartAfterInstallCount) {
+                Write-Log 'Restarting worker node completed'
+                break;
+            }
+        }
+    }
+} 
+
+Write-Log "Current state of kubernetes nodes:`n"
+Start-Sleep 2
+$kubeToolsPath = Get-KubeToolsPath
+&"$kubeToolsPath\kubectl.exe" get nodes -o wide 2>&1 | ForEach-Object { "$_" } | Write-Log
+
+Write-Log '---------------------------------------------------------------'
+Write-Log "Linux computer with IP '$IpAddress' and hostname '$NodeName' added to the cluster.   Total duration: $('{0:hh\:mm\:ss}' -f $durationStopwatch.Elapsed )"
+Write-Log '---------------------------------------------------------------'
+

--- a/lib/scripts/worker-node/linux/bare-metal/Remove.ps1
+++ b/lib/scripts/worker-node/linux/bare-metal/Remove.ps1
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
+#
+# SPDX-License-Identifier: MIT
+
+#Requires -RunAsAdministrator
+
+Param(
+    [string] $NodeName = $(throw 'Argument missing: NodeName'),
+    [string] $UserName = $(throw 'Argument missing: UserName'),
+    [string] $IpAddress = $(throw 'Argument missing: IpAddress'),
+    [switch] $ShowLogs = $false,
+    [string] $AdditionalHooksDir = '',
+    [switch] $SkipHeaderDisplay = $false
+)
+
+$preparationStopwatch = [system.diagnostics.stopwatch]::StartNew()
+
+$infraModule =   "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.infra.module\k2s.infra.module.psm1"
+$nodeModule =    "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.node.module\k2s.node.module.psm1"
+$clusterModule = "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.cluster.module\k2s.cluster.module.psm1"
+Import-Module $infraModule, $nodeModule, $clusterModule
+
+Initialize-Logging -ShowLogs:$ShowLogs
+
+$ErrorActionPreference = 'Stop'
+
+# make sure we are at the right place for install
+$installationPath = Get-KubePath
+Set-Location $installationPath
+
+# check if the computer is already part of the cluster
+$k8sFormattedNodeName = $NodeName.ToLower()
+$clusterState = (Invoke-Kubectl -Params @('get', 'nodes', '-o', 'wide')).Output
+if ($clusterState -notmatch $k8sFormattedNodeName) {
+    Write-Log "The node '$k8sFormattedNodeName' is not part of the cluster."
+}
+
+$connectionCheck = (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'which ls' -UserName $UserName -IpAddress $IpAddress)
+if (!$connectionCheck.Success) {
+    throw "Cannot connect to the computer with IP address '$IpAddress'."
+}
+
+$k8sFormattedNodeName = $NodeName.ToLower()
+$actualHostname = (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'echo $(hostname)' -UserName $UserName -IpAddress $IpAddress).Output
+if ($k8sFormattedNodeName -ne $actualHostname.ToLower()) {
+    throw "The passed NodeName '$NodeName' is not the name of the node with IP '$IpAddress' ($actualHostname)"
+}
+
+Write-Log 'Stop the worker node'
+& "$PSScriptRoot\Stop.ps1" -AdditionalHooksDir $AdditionalHooksDir -ShowLogs:$ShowLogs -SkipHeaderDisplay:$SkipHeaderDisplay -NodeName $NodeName
+
+$workerNodeParams = @{
+    NodeName = $NodeName
+    UserName = $UserName
+    IpAddress = $IpAddress
+    SkipHeaderDisplay = $SkipHeaderDisplay
+    AdditionalHooksDir = $AdditionalHooksDir
+}
+Remove-LinuxWorkerNodeOnUbuntuBareMetal @workerNodeParams
+
+Write-Log "Current state of kubernetes nodes:`n"
+Start-Sleep 2
+$kubeToolsPath = Get-KubeToolsPath
+&"$kubeToolsPath\kubectl.exe" get nodes -o wide 2>&1 | ForEach-Object { "$_" } | Write-Log
+
+Write-Log '---------------------------------------------------------------'
+Write-Log "Linux computer with IP '$IpAddress' and hostname '$NodeName' removed from the cluster.   Total duration: $('{0:hh\:mm\:ss}' -f $preparationStopwatch.Elapsed )"
+Write-Log '---------------------------------------------------------------'
+

--- a/lib/scripts/worker-node/linux/bare-metal/Start.ps1
+++ b/lib/scripts/worker-node/linux/bare-metal/Start.ps1
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
+#
+# SPDX-License-Identifier: MIT
+
+#Requires -RunAsAdministrator
+
+
+Param(
+    [string] $IpAddress = $(throw 'Argument missing: IpAddress'),
+    [string] $NodeName = $(throw 'Argument missing: NodeName'),
+    [switch] $ShowLogs = $false,
+    [string] $AdditionalHooksDir = '',
+    [switch] $SkipHeaderDisplay = $false
+)
+
+$infraModule = "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.infra.module\k2s.infra.module.psm1"
+$nodeModule = "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.node.module\k2s.node.module.psm1"
+$clusterModule = "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.cluster.module\k2s.cluster.module.psm1"
+$addonsModule = "$PSScriptRoot\..\..\..\..\..\addons\addons.module.psm1"
+Import-Module $infraModule, $nodeModule, $clusterModule, $addonsModule
+
+Initialize-Logging -ShowLogs:$ShowLogs
+$kubePath = Get-KubePath
+
+# make sure we are at the right place for executing this script
+Set-Location $kubePath
+
+$ProgressPreference = 'SilentlyContinue'
+
+$workerNodeName = $NodeName.ToLower()
+
+$workerNodeStartParams = @{
+    AdditionalHooksDir = $AdditionalHooksDir
+    SkipHeaderDisplay = $SkipHeaderDisplay
+    IpAddress = $IpAddress
+    NodeName = $workerNodeName
+}
+Start-LinuxWorkerNodeOnUbuntuBareMetal @workerNodeStartParams

--- a/lib/scripts/worker-node/linux/bare-metal/Stop.ps1
+++ b/lib/scripts/worker-node/linux/bare-metal/Stop.ps1
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
+#
+# SPDX-License-Identifier: MIT
+
+#Requires -RunAsAdministrator
+
+Param(
+    [string] $NodeName = $(throw 'Argument missing: NodeName'),
+    [switch] $ShowLogs = $false,
+    [string] $AdditionalHooksDir = '',
+    [switch] $SkipHeaderDisplay = $false
+)
+
+$infraModule = "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.infra.module\k2s.infra.module.psm1"
+$nodeModule = "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.node.module\k2s.node.module.psm1"
+$clusterModule = "$PSScriptRoot\..\..\..\..\modules\k2s\k2s.cluster.module\k2s.cluster.module.psm1"
+Import-Module $infraModule, $nodeModule, $clusterModule
+
+Initialize-Logging -ShowLogs:$ShowLogs
+
+# make sure we are at the right place for executing this script
+$kubePath = Get-KubePath
+Set-Location $kubePath
+
+$ProgressPreference = 'SilentlyContinue'
+
+$workerNodeName = $NodeName.ToLower()
+
+$workerNodeStopParams = @{
+    AdditionalHooksDir = $AdditionalHooksDir
+    SkipHeaderDisplay  = $SkipHeaderDisplay
+    NodeName           = $workerNodeName 
+}
+Stop-LinuxWorkerNodeOnUbuntuBareMetal @workerNodeStopParams
+
+


### PR DESCRIPTION
#39

Adds / removes an Ubuntu bare metal node to / from the cluster.

**Restrictions:**
- the computer to add must be on the network of the Windows node.
- only Ubuntu 22.04 and 24.04 are currently supported.
- only the networking between Linux nodes is supported.
- after removal swap remains disabled in the removed node.

**Preconditions:**

- the computer to add has internet connectivity.
- the ssh server must be running in the computer to add.
  - if not, install it by calling: `sudo apt install openssh-server`
- the user for remote connections (e.g. userInComputerToAdd) must be listed in the /etc/sudoers file like the following:
  - _userInComputerToAdd ALL=(ALL) NOPASSWD:ALL_
- K2s must be installed on the Windows host
- the public key of K2s must be copied into the computer to add:
  - call: `type %USERPROFILE%\.ssh\kubemaster\id_rsa.pub | ssh userInComputerToAdd@IPofComputerToAdd "cat | sudo tee -a ~/.ssh/authorized_keys"`

**To add the computer to the cluster:**

Assumptions:
- the Windows host has the IP address 192.168.178.80
- the computer to add has the IP address 192.168.178.30

call: `".\lib\scripts\worker-node\linux\bare-metal\Add.ps1 -NodeName 'hostnameOfComputerToAdd' -UserName 'userInComputerToAdd' -IpAddress '192.168.178.30' -WindowsHostIpAddress '192.168.178.80'"`

**To remove the node from the cluster:**

call `".\lib\scripts\worker-node\linux\bare-metal\Remove.ps1 -NodeName 'hostnameOfComputerToAdd' -UserName 'userInComputerToAdd' -IpAddress '192.168.178.30'"`

After removal you'll have to do the following:

- reenable swap if it was enabled before.
