### PR TITLE
feat(e2e): added sanity tag

### DIFF
--- a/k2s/test/e2e/cluster/core/core_test.go
+++ b/k2s/test/e2e/cluster/core/core_test.go
@@ -32,7 +32,7 @@ var testFailed = false
 
 func TestClusterCore(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Cluster Core Acceptance Tests", Label("core", "acceptance", "internet-required", "setup-required", "system-running"))
+	RunSpecs(t, "Cluster Core Acceptance Tests", Label("core", "acceptance", "internet-required", "setup-required", "system-running", "sanity"))
 }
 
 var _ = BeforeSuite(func(ctx context.Context) {


### PR DESCRIPTION
Added sanity tag for communication test to avoid tag "core" interference with "users" feature.
Needs adaptation in release 1.1.x line and in the pipeline.