### PR TITLE
fix(build-image-e2e): enable ingress nginx

### DIFF
--- a/k2s/test/e2e/addons/generic/build_image/build_image_test.go
+++ b/k2s/test/e2e/addons/generic/build_image/build_image_test.go
@@ -55,6 +55,7 @@ var _ = Describe("build container image", Ordered, func() {
 	When("Default Ingress", func() {
 		Context("registry addon is enabled {nginx}", func() {
 			BeforeAll(func(ctx context.Context) {
+				suite.K2sCli().Run(ctx, "addons", "enable", "ingress", "nginx", "-o")
 				suite.K2sCli().Run(ctx, "addons", "enable", "registry", "-o")
 			})
 


### PR DESCRIPTION
Enable ingress for registry access as default ingress option is not valid anymore.