### PR TITLE
refactor(install): reintroduce no pwd access to control plane

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
@@ -87,6 +87,8 @@ function New-ControlPlaneNodeOnNewVM {
     Copy-LocalPublicSshKeyToRemoteComputer -UserName $(Get-DefaultUserNameControlPlane) -UserPwd $(Get-DefaultUserPwdControlPlane) -IpAddress $($controlPlaneParams.IpAddress)
     Wait-ForSSHConnectionToLinuxVMViaSshKey
 
+    Remove-ControlPlaneAccessViaUserAndPwd
+    
     # add kubectl to Windows host
     Install-KubectlTool
     # copy kubectl config file into Windows host


### PR DESCRIPTION
Reintroduce the deletion of pwd access into the VM acting as control plane after its installation.