### PR TITLE
feat(node): renamed ssh keys folder

### DIFF
--- a/docs/op-manual/adding-k2s-users.md
+++ b/docs/op-manual/adding-k2s-users.md
@@ -48,7 +48,7 @@ See `k2s system users add -h` for more options.
 ??? example "Full Example With Detailed Steps"
     Given that the *Windows* user `desktop1234\john` exists on the host and has a local profile/home directory, the *K2s* admin runs `k2s system users add -u john` which triggers the following steps:
     
-    - Creating an SSH key pair for *John* in `c:\users\john\.ssh\kubemaster\` on the host. The admin must confirm overwriting existing key pairs. Since the SSH key pair was initially created by the admin's *Windows* account, the file security inheritance must be disabled, the *Administrators* group granted full file access (so that the *K2s* admin can revoke/delete *John's* access later) and the admin user must be removed from the ACL, otherwise SSH would complain about too open access permissions when *John* tries to use his SSH key. *John's* public SSH key contains the *K2s*-specific username as comment, i.e. `k2s-desktop1234-john`, so that removing entries only targets SSH fingerprints that have been created by *K2s*. As of now, none of the SSH keys being created by *K2s* are password-protected.
+    - Creating an SSH key pair for *John* in `c:\users\john\.ssh\k2s\` on the host. The admin must confirm overwriting existing key pairs. Since the SSH key pair was initially created by the admin's *Windows* account, the file security inheritance must be disabled, the *Administrators* group granted full file access (so that the *K2s* admin can revoke/delete *John's* access later) and the admin user must be removed from the ACL, otherwise SSH would complain about too open access permissions when *John* tries to use his SSH key. *John's* public SSH key contains the *K2s*-specific username as comment, i.e. `k2s-desktop1234-john`, so that removing entries only targets SSH fingerprints that have been created by *K2s*. As of now, none of the SSH keys being created by *K2s* are password-protected.
     - Adding control-plane's SSH fingerprint to `c:\users\john\.ssh\known_hosts` file on the host. It removes previous control-plane fingerprint if existing.
     - Adding *John's* SSH fingerprint to `~/.ssh/authorized_keys` on the control-plane. It removes *John's* previous fingerprint if existing.
     - Creating `c:\users\john\.kube\config` if not existing, copying the *K2s* cluster configuration from admin's `kubeconfig`.
@@ -64,7 +64,7 @@ See `k2s system users add -h` for more options.
 The new user can verify the SSH access to the control-plane by running:
 
 ```console
-ssh -o StrictHostKeyChecking=no -i "~/.ssh\kubemaster\id_rsa" "remote@172.19.1.100"
+ssh -o StrictHostKeyChecking=no -i "~/.ssh\k2s\id_rsa" "remote@172.19.1.100"
 ```
 
 where `172.19.1.100` is the IP address of the control-plane and `remote` the *Linux* user with admin privileges.
@@ -134,7 +134,7 @@ There is no automated or bullet-proof way to revoke access to *K2s* (or removing
 
 ### Control-plane
 - \[Essential\] On control-plane, remove SSH key fingerprint from `~/.ssh/authorized_keys` for the specific user (entry should contain username with `k2s-` prefix).
-- \[Cleanup\] Remove SSH key pair folder `<home-dir>\.ssh\kubemaster\`.
+- \[Cleanup\] Remove SSH key pair folder `<home-dir>\.ssh\k2s\`.
 - \[Cleanup\] Remove control-plane fingerprint from `<home-dir>\.ssh\known_hosts`, normally starting with the control-plane's IP address `172.19.1.100`.
 
 ### *K8s* API

--- a/docs/op-manual/extending-k2s-cluster.md
+++ b/docs/op-manual/extending-k2s-cluster.md
@@ -33,25 +33,25 @@ This guide explains how to extend a K2s cluster by adding physical hosts or virt
 
 ### 1. Copy the public SSH Key to the new node
 
-When K2s is installed, an SSH public key is available under the directory `%USERPROFILE%\.ssh\kubemaster\id_rsa.pub`.
+When K2s is installed, an SSH public key is available under the directory `%USERPROFILE%\.ssh\k2s\id_rsa.pub`.
 This key must be copied to the physical host or VM to establish communication and initiate the installation.
 
 #### Manually
 
-Copy the file from `%USERPROFILE%\.ssh\kubemaster\id_rsa.pub` to any location on the machine `e.g. /tmp/ on Linux host` .
+Copy the file from `%USERPROFILE%\.ssh\k2s\id_rsa.pub` to any location on the machine `e.g. /tmp/ on Linux host` .
 
 #### Using `scp` and password
 
 ##### Linux New Node
 
 ```cmd
-scp -o StrictHostKeyChecking=no %USERPROFILE%\.ssh\kubemaster\id_rsa.pub  <usernameOfNode>@<IpAddressOfNode>:/tmp/temp_k2s.pub
+scp -o StrictHostKeyChecking=no %USERPROFILE%\.ssh\k2s\id_rsa.pub  <usernameOfNode>@<IpAddressOfNode>:/tmp/temp_k2s.pub
 ```
 
 ##### Windows New Node
 
 ```cmd
-scp -o StrictHostKeyChecking=no %USERPROFILE%\.ssh\kubemaster\id_rsa.pub  <usernameOfNode>@<IpAddressOfNode>:c:\\temp\\temp_k2s.pub
+scp -o StrictHostKeyChecking=no %USERPROFILE%\.ssh\k2s\id_rsa.pub  <usernameOfNode>@<IpAddressOfNode>:c:\\temp\\temp_k2s.pub
 ```
 
 !!! hint "scp"

--- a/k2s/internal/core/node/ssh/ssh.go
+++ b/k2s/internal/core/node/ssh/ssh.go
@@ -26,7 +26,7 @@ const (
 	DefaultPort   uint16 = 22
 
 	sshKeyName    = "id_rsa"
-	sshSubDirName = "kubemaster" // TODO: this will change to a more generic sub dir name in the near future
+	sshSubDirName = "k2s"
 )
 
 func SshKeyPath(sshDir string) string {

--- a/k2s/internal/core/node/ssh/ssh_test.go
+++ b/k2s/internal/core/node/ssh/ssh_test.go
@@ -43,7 +43,7 @@ var _ = Describe("ssh pkg", func() {
 		It("constructs SSH key path correctly", func() {
 			actual := ssh.SshKeyPath("my-dir")
 
-			Expect(actual).To(Equal("my-dir\\kubemaster\\id_rsa"))
+			Expect(actual).To(Equal("my-dir\\k2s\\id_rsa"))
 		})
 	})
 

--- a/k2s/test/e2e/cli/cmd/node/setuprequired/systemrunning/copy/copy_system-running_test.go
+++ b/k2s/test/e2e/cli/cmd/node/setuprequired/systemrunning/copy/copy_system-running_test.go
@@ -89,7 +89,7 @@ var _ = Describe("node copy", Ordered, func() {
 				sshExec = &sshExecutor{
 					ipAddress:  nodeIpAddress,
 					remoteUser: "remote",
-					keyPath:    "~/.ssh\\kubemaster\\id_rsa",
+					keyPath:    "~/.ssh\\k2s\\id_rsa",
 					execFunc:   suite.Cli().ExecOrFail,
 				}
 
@@ -532,7 +532,7 @@ var _ = Describe("node copy", Ordered, func() {
 				sshExec = &sshExecutor{
 					ipAddress:  nodeIpAddress,
 					remoteUser: remoteUser,
-					keyPath:    "~/.ssh\\kubemaster\\id_rsa",
+					keyPath:    "~/.ssh\\k2s\\id_rsa",
 					execFunc:   suite.Cli().ExecOrFail,
 				}
 
@@ -996,7 +996,7 @@ var _ = Describe("node copy", Ordered, func() {
 					sshExec = &sshExecutor{
 						ipAddress:  nodeIpAddress,
 						remoteUser: "remote",
-						keyPath:    "~/.ssh\\kubemaster\\id_rsa",
+						keyPath:    "~/.ssh\\k2s\\id_rsa",
 						execFunc:   suite.Cli().ExecOrFail,
 					}
 
@@ -1421,7 +1421,7 @@ var _ = Describe("node copy", Ordered, func() {
 					sshExec = &sshExecutor{
 						ipAddress:  nodeIpAddress,
 						remoteUser: remoteUser,
-						keyPath:    "~/.ssh\\kubemaster\\id_rsa",
+						keyPath:    "~/.ssh\\k2s\\id_rsa",
 						execFunc:   suite.Cli().ExecOrFail,
 					}
 

--- a/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/users/users_systemrunning_test.go
+++ b/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/users/users_systemrunning_test.go
@@ -90,7 +90,7 @@ var _ = Describe("system users add", Ordered, func() {
 			})
 			Expect(found).To(BeTrue())
 			expectedRemoteUser = "remote@" + controlPlaneConfig.IpAddress
-			expectedKeyPath = filepath.Join(fakeHomeDir, `.ssh\kubemaster\id_rsa`)
+			expectedKeyPath = filepath.Join(fakeHomeDir, `.ssh\k2s\id_rsa`)
 
 			systemUserWithFakeHomeDir := winusers.NewUser(systemUserId, systemUserName, fakeHomeDir)
 

--- a/lib/modules/k2s/k2s.infra.module/config/config.module.psm1
+++ b/lib/modules/k2s/k2s.infra.module/config/config.module.psm1
@@ -38,7 +38,7 @@ $k2sConfigDir = Expand-Path $configDir.psobject.properties['k2s'].value
 
 $sshKeyFileName = 'id_rsa'
 $kubernetesImagesJsonFile = "$k2sConfigDir\kubernetes_images.json"
-$sshKeyControlPlane = "$sshConfigDir\kubemaster\$sshKeyFileName"
+$sshKeyControlPlane = "$sshConfigDir\k2s\$sshKeyFileName"
 
 #NETWORKING
 $ipControlPlane = $smallsetup.psobject.properties['masterIP'].value

--- a/lib/modules/k2s/k2s.node.module/linuxnode/security/security.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/security/security.module.psm1
@@ -50,6 +50,9 @@ function Remove-SshKey {
     )
     Write-Log 'Remove control plane ssh keys from host'
     ssh-keygen.exe -R $IpAddress 2>&1 | % { "$_" } | Out-Null
+    Remove-Item -Path ($sshConfigDir + '\k2s') -Force -Recurse -ErrorAction SilentlyContinue
+
+    # remove old folder where the ssh key was located
     Remove-Item -Path ($sshConfigDir + '\kubemaster') -Force -Recurse -ErrorAction SilentlyContinue
 }
 

--- a/smallsetup/common/GlobalVariables.ps1
+++ b/smallsetup/common/GlobalVariables.ps1
@@ -74,7 +74,7 @@ $configDir = $clusterConfig.psobject.properties['configDir'].value
 
 $global:SshConfigDir = Force-Resolve-Path $configDir.psobject.properties['ssh'].value
 $global:keyFileName = 'id_rsa'
-$global:LinuxVMKey = $global:SshConfigDir + "\kubemaster\$global:keyFileName"
+$global:LinuxVMKey = $global:SshConfigDir + "\k2s\$global:keyFileName"
 $global:WindowsVMKey = $global:SshConfigDir + "\windowsvm\$global:keyFileName"
 
 $global:K2sConfigDir = Force-Resolve-Path $configDir.psobject.properties['k2s'].value


### PR DESCRIPTION
#39 

Renamed the folder where the k2s ssh key pair is located from "%USERPROFILE%\\.ssh\kubemaster" to "%USERPROFILE%\\.ssh\k2s"