### PR TITLE
feat(node): Linux offline package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ containerd/nerdctl.exe
 /bin/windowsnode
 /bin/WindowsNodeArtifacts.zip
 /bin/linuxnode
+/bin/LinuxNodeArtifacts.zip
 
 bin/msiinstall.log
 bin/msiuninstall.log

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -19,9 +19,12 @@ $kubernetesDebPackagesDirectory = 'kubernetes'
 $buildahDebPackagesDirectory = 'buildah'
 
 $binPath = Get-KubeBinPath
-$linuxNodePath = "$binPath\linuxnode"
-$windowsHostKubenodeDebPackagesPath = "$linuxNodePath\packages"
-$windowsHostKubenodeImagesPath = "$linuxNodePath\images"
+$directoryOfLinuxNodeArtifactsOnWindowsHost = "$binPath\linuxnode"
+$baseDirectoryOfKubenodeDebPackagesOnWindowsHost = "$directoryOfLinuxNodeArtifactsOnWindowsHost\packages"
+$directoryOfKubenodeImagesOnWindowsHost = "$directoryOfLinuxNodeArtifactsOnWindowsHost\images"
+
+$linuxNodeArtifactsZipFileName = 'LinuxNodeArtifacts.zip'
+$pathOfLinuxNodeArtifactsPackageOnWindowsHost = "$binPath\$linuxNodeArtifactsZipFileName"
 
 Function Assert-GeneralComputerPrequisites {
     Param(
@@ -348,7 +351,7 @@ Function Copy-DebPackagesFromControlPlaneToWindowsHost {
         Write-Log "The path '$windowsHostTargetPath' with deb packages from the control plane already exists --> its content will not be overwritten"
     } else {
         $kubenodeSourcePath = Get-OfflineK2sDebPackagesPath -UserName $controlPlaneUserName
-        Write-Log "Checking existence of path '$kubenodeSourcePath' in the control plane node"
+        Write-Log "Checking the existence of path '$kubenodeSourcePath' in the control plane node"
         $sourcePathExistenceCheckOutput = (Invoke-CmdOnVmViaSSHKey -CmdToExecute "ls $kubenodeSourcePath" -UserName $controlPlaneUserName -IpAddress $controlPlaneIpAddress -IgnoreErrors).Output
         
         if ($sourcePathExistenceCheckOutput.Contains("No such file or directory")) {
@@ -600,7 +603,7 @@ Function Copy-KubernetesImagesFromControlPlaneToRemoteComputer {
         (Invoke-CmdOnVmViaSSHKey -CmdToExecute $command -UserName $UserName -IpAddress $IpAddress -Retries $Retries -RepairCmd $RepairCmd -IgnoreErrors:$IgnoreErrors).Output | Write-Log
     }
 
-    $imagesPath = $windowsHostKubenodeImagesPath
+    $imagesPath = $directoryOfKubenodeImagesOnWindowsHost
 
     Write-Log "Copy container images from the control plane node to the Windows host"
     Copy-KubernetesImagesFromControlPlaneNodeToWindowsHost -TargetPath $imagesPath
@@ -1872,8 +1875,20 @@ function Set-ProxySettingsForContainers {
     }
 }
 
-function Get-WindowsHostKubenodeDebPackagesPath {
-    return $windowsHostKubenodeDebPackagesPath
+function Get-BaseDirectoryOfKubenodeDebPackagesOnWindowsHost {
+    return $baseDirectoryOfKubenodeDebPackagesOnWindowsHost
+}
+
+function Get-DirectoryOfKubenodeImagesOnWindowsHost {
+    return $directoryOfKubenodeImagesOnWindowsHost
+}
+
+function Get-DirectoryOfLinuxNodeArtifactsOnWindowsHost {
+    return $directoryOfLinuxNodeArtifactsOnWindowsHost
+}
+
+function Get-PathOfLinuxNodeArtifactsPackageOnWindowsHost {
+    return $pathOfLinuxNodeArtifactsPackageOnWindowsHost
 }
 
 Export-ModuleMember -Function New-VmImageForControlPlaneNode,
@@ -1895,4 +1910,8 @@ Install-BuildahDebPackages,
 Set-UpComputerBeforeProvisioning,
 Copy-DebPackagesFromControlPlaneToWindowsHost,
 Get-InstalledDistribution,
-Get-WindowsHostKubenodeDebPackagesPath
+Get-BaseDirectoryOfKubenodeDebPackagesOnWindowsHost,
+Get-DirectoryOfKubenodeImagesOnWindowsHost,
+Get-DirectoryOfLinuxNodeArtifactsOnWindowsHost,
+Get-PathOfLinuxNodeArtifactsPackageOnWindowsHost,
+Copy-KubernetesImagesFromControlPlaneNodeToWindowsHost

--- a/lib/scripts/k2s/system/package/New-LinuxNodeArtifactsPackage.ps1
+++ b/lib/scripts/k2s/system/package/New-LinuxNodeArtifactsPackage.ps1
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
+#
+# SPDX-License-Identifier: MIT
+
+#Requires -RunAsAdministrator
+
+param (
+        [parameter(Mandatory = $false, HelpMessage = 'Delete the sources used to create the package')]
+	[switch] $DeleteSourcesAfterCreation = $false,
+        [parameter(Mandatory = $false, HelpMessage = 'Show all logs in terminal')]
+        [switch] $ShowLogs = $false
+	)
+
+$infraModule = "$PSScriptRoot/../../../../modules/k2s/k2s.infra.module/k2s.infra.module.psm1"
+$nodeModule = "$PSScriptRoot/../../../../modules/k2s/k2s.node.module/k2s.node.module.psm1"
+$clusterModule = "$PSScriptRoot/../../../../modules/k2s/k2s.cluster.module/k2s.cluster.module.psm1"
+Import-Module $infraModule, $nodeModule, $clusterModule
+
+Initialize-Logging -ShowLogs:$ShowLogs
+
+$controlPlaneUserName = Get-DefaultUserNameControlPlane
+$controlPlaneIpAddress = Get-ConfiguredIPControlPlane
+
+$installedDistributionOnControlPlane = Get-InstalledDistribution -UserName $controlPlaneUserName -IpAddress $controlPlaneIpAddress
+$baseDirectoryOfDebPackagesOnWindowsHost = Get-BaseDirectoryOfKubenodeDebPackagesOnWindowsHost
+$directoryOfDistributionDebPackagesOnWindowsHost = "$baseDirectoryOfDebPackagesOnWindowsHost\$installedDistributionOnControlPlane"
+
+Copy-DebPackagesFromControlPlaneToWindowsHost -TargetPath $directoryOfDistributionDebPackagesOnWindowsHost
+
+$imagesDirectory = Get-DirectoryOfKubenodeImagesOnWindowsHost
+Copy-KubernetesImagesFromControlPlaneNodeToWindowsHost -TargetPath $imagesDirectory
+
+$sourceDirectory = Get-DirectoryOfLinuxNodeArtifactsOnWindowsHost
+$targetPath = Get-PathOfLinuxNodeArtifactsPackageOnWindowsHost
+
+if (Test-Path($targetPath)) {
+        Write-Log "Remove already existing file '$targetPath'"
+        Remove-Item $targetPath -Force
+}
+
+Write-Log "Create compressed file '$targetPath' with artifacts for a Linux node..."
+Compress-Archive -Path "$sourceDirectory\*" -DestinationPath "$targetPath" -Force
+Write-Log "  done"
+
+if ($DeleteSourcesAfterCreation) {
+    Write-Log "Remove directory '$sourceDirectory'"
+    Remove-Item "$sourceDirectory" -Recurse -Force
+}


### PR DESCRIPTION
#39 

Added the script `.\lib\scripts\k2s\system\package\New-LinuxNodeArtifactsPackage.ps1` to create the file `.\bin\LinuxNodeArtifacts.zip` that contains the content of the folder `.\bin\linuxnode` where the deb packages and container images are located for setting up kubernetes in offline mode in a new Linux node.

The folder `.\bin\linuxnode` contains two subfolders:
- `packages` contains distribution specific deb packages separated in subfolders named according to the distribution name and version.
- `images` contains container images.

The logic populates the above mentioned folders with artifacts taken from the Control Plane VM (i.e. KubeMaster) if they are not present in the file system, otherwise their content will not be overwritten.

This Pull Request also adds the logic to use the content of the file `LinuxNodeArtifacts.zip` for adding a new Linux node in offline mode.

The logic works as follows:
- is the folder `.\bin\linuxnode` not available but the file `.\bin\LinuxNodeArtifacts.zip` is available? --> the zip file will be unzipped under `.\bin\linuxnode`.
- is the folder `'.\bin\linuxnode\packages\<installed distribution in the node to add>'` available? --> its content will be copied into the node to be added to the cluster.
- is the folder `'.\bin\linuxnode\images'` available? --> its content will be copied into the node to be added to the cluster.




