### PR TITLE
fix: update license header

### DIFF
--- a/addons/autoscaling/Get-Status.ps1
+++ b/addons/autoscaling/Get-Status.ps1
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/addons/autoscaling/manifests/keda-2.15.1.yaml
+++ b/addons/autoscaling/manifests/keda-2.15.1.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/addons/security/manifests/keycloak/keycloak.yaml
+++ b/addons/security/manifests/keycloak/keycloak.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/addons/security/manifests/keycloak/nginx-ingress.yaml
+++ b/addons/security/manifests/keycloak/nginx-ingress.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/addons/security/manifests/keycloak/oauth2-proxy.yaml
+++ b/addons/security/manifests/keycloak/oauth2-proxy.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/addons/security/manifests/keycloak/traefik-ingress.yaml
+++ b/addons/security/manifests/keycloak/traefik-ingress.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/k2s/cmd/k2s/cmd/image/registry/remove.go
+++ b/k2s/cmd/k2s/cmd/image/registry/remove.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package registry

--- a/k2s/cmd/k2s/cmd/system/proxy/override/override.go
+++ b/k2s/cmd/k2s/cmd/system/proxy/override/override.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package override

--- a/k2s/cmd/k2s/cmd/system/proxy/override/override_add.go
+++ b/k2s/cmd/k2s/cmd/system/proxy/override/override_add.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package override

--- a/k2s/cmd/k2s/cmd/system/proxy/override/override_delete.go
+++ b/k2s/cmd/k2s/cmd/system/proxy/override/override_delete.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package override

--- a/k2s/cmd/k2s/cmd/system/proxy/override/override_ls.go
+++ b/k2s/cmd/k2s/cmd/system/proxy/override/override_ls.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package override

--- a/k2s/cmd/k2s/cmd/system/proxy/proxy.go
+++ b/k2s/cmd/k2s/cmd/system/proxy/proxy.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package proxy

--- a/k2s/cmd/k2s/cmd/system/proxy/proxy_get.go
+++ b/k2s/cmd/k2s/cmd/system/proxy/proxy_get.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package proxy

--- a/k2s/cmd/k2s/cmd/system/proxy/proxy_reset.go
+++ b/k2s/cmd/k2s/cmd/system/proxy/proxy_reset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package proxy

--- a/k2s/cmd/k2s/cmd/system/proxy/proxy_set.go
+++ b/k2s/cmd/k2s/cmd/system/proxy/proxy_set.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package proxy

--- a/k2s/cmd/k2s/cmd/system/proxy/proxy_show.go
+++ b/k2s/cmd/k2s/cmd/system/proxy/proxy_show.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package proxy

--- a/k2s/cmd/k2s/cmd/system/users/add.go
+++ b/k2s/cmd/k2s/cmd/system/users/add.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package users

--- a/k2s/cmd/k2s/cmd/system/users/users.go
+++ b/k2s/cmd/k2s/cmd/system/users/users.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package users

--- a/k2s/cmd/k2s/cmd/system/users/users_test.go
+++ b/k2s/cmd/k2s/cmd/system/users/users_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package users

--- a/k2s/internal/core/node/ssh/keygen/keygen.go
+++ b/k2s/internal/core/node/ssh/keygen/keygen.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package keygen

--- a/k2s/internal/core/node/ssh/keygen/keygen_test.go
+++ b/k2s/internal/core/node/ssh/keygen/keygen_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package keygen_test

--- a/k2s/internal/core/users/acl/acl.go
+++ b/k2s/internal/core/users/acl/acl.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package acl

--- a/k2s/internal/core/users/add.go
+++ b/k2s/internal/core/users/add.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package users

--- a/k2s/internal/core/users/common/common.go
+++ b/k2s/internal/core/users/common/common.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package common

--- a/k2s/internal/core/users/controlplane/controlplane.go
+++ b/k2s/internal/core/users/controlplane/controlplane.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package controlplane

--- a/k2s/internal/core/users/fs/fs.go
+++ b/k2s/internal/core/users/fs/fs.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package fs

--- a/k2s/internal/core/users/http/http.go
+++ b/k2s/internal/core/users/http/http.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package http

--- a/k2s/internal/core/users/http/http_test.go
+++ b/k2s/internal/core/users/http/http_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package http_test

--- a/k2s/internal/core/users/k8s/cluster/cluster.go
+++ b/k2s/internal/core/users/k8s/cluster/cluster.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package cluster

--- a/k2s/internal/core/users/k8s/cluster/cluster_test.go
+++ b/k2s/internal/core/users/k8s/cluster/cluster_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package cluster_test

--- a/k2s/internal/core/users/k8s/k8s.go
+++ b/k2s/internal/core/users/k8s/k8s.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package k8s

--- a/k2s/internal/core/users/k8s/k8s_test.go
+++ b/k2s/internal/core/users/k8s/k8s_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package k8s_test

--- a/k2s/internal/core/users/k8s/kubeconfig/kubeconfig.go
+++ b/k2s/internal/core/users/k8s/kubeconfig/kubeconfig.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package kubeconfig

--- a/k2s/internal/core/users/k8s/kubeconfig/kubeconfig_test.go
+++ b/k2s/internal/core/users/k8s/kubeconfig/kubeconfig_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package kubeconfig_test

--- a/k2s/internal/core/users/naming.go
+++ b/k2s/internal/core/users/naming.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package users

--- a/k2s/internal/core/users/users.go
+++ b/k2s/internal/core/users/users.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package users

--- a/k2s/internal/core/users/users_test.go
+++ b/k2s/internal/core/users/users_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package users_test

--- a/k2s/internal/core/users/winusers/winusers.go
+++ b/k2s/internal/core/users/winusers/winusers.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package winusers

--- a/k2s/internal/core/users/winusers/winusers_test.go
+++ b/k2s/internal/core/users/winusers/winusers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package winusers_test

--- a/k2s/internal/os/os.go
+++ b/k2s/internal/os/os.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package os

--- a/k2s/internal/os/os_test.go
+++ b/k2s/internal/os/os_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package os_test

--- a/k2s/internal/yaml/yaml.go
+++ b/k2s/internal/yaml/yaml.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package yaml

--- a/k2s/internal/yaml/yaml_test.go
+++ b/k2s/internal/yaml/yaml_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package yaml_test

--- a/k2s/test/e2e/addons/autoscaling/autoscaling_test.go
+++ b/k2s/test/e2e/addons/autoscaling/autoscaling_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 //
 // SPDX-License-Identifier: MIT
 

--- a/k2s/test/e2e/addons/rollout/rollout_test.go
+++ b/k2s/test/e2e/addons/rollout/rollout_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 //
 // SPDX-License-Identifier: MIT
 

--- a/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/dump/dump_systemrunning_test.go
+++ b/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/dump/dump_systemrunning_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package dump

--- a/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/scp/scp_systemrunning_test.go
+++ b/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/scp/scp_systemrunning_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package scp

--- a/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/ssh/ssh_systemrunning_test.go
+++ b/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/ssh/ssh_systemrunning_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package ssh

--- a/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/users/users_systemrunning_test.go
+++ b/k2s/test/e2e/cli/cmd/system/setuprequired/systemrunning/users/users_systemrunning_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText:  © 2024 Siemens Healthcare AG
+// SPDX-FileCopyrightText:  © 2024 Siemens Healthineers AG
 // SPDX-License-Identifier:   MIT
 
 package users_test

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/certificate/ZScalerRootCA.crt
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/certificate/ZScalerRootCA.crt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/certificate/ZScalerRootCA.crt.license
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/certificate/ZScalerRootCA.crt.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 
 SPDX-License-Identifier: MIT

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 # SPDX-License-Identifier: MIT
 
 #Requires -RunAsAdministrator

--- a/lib/scripts/k2s/system/proxy/GetProxy.ps1
+++ b/lib/scripts/k2s/system/proxy/GetProxy.ps1
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/lib/scripts/k2s/system/proxy/ResetProxy.ps1
+++ b/lib/scripts/k2s/system/proxy/ResetProxy.ps1
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/lib/scripts/k2s/system/proxy/SetProxy.ps1
+++ b/lib/scripts/k2s/system/proxy/SetProxy.ps1
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/lib/scripts/k2s/system/proxy/override/AddProxyOverride.ps1
+++ b/lib/scripts/k2s/system/proxy/override/AddProxyOverride.ps1
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/lib/scripts/k2s/system/proxy/override/DeleteProxyOverride.ps1
+++ b/lib/scripts/k2s/system/proxy/override/DeleteProxyOverride.ps1
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 

--- a/lib/scripts/k2s/system/proxy/override/ListProxyOverrides.ps1
+++ b/lib/scripts/k2s/system/proxy/override/ListProxyOverrides.ps1
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthcare AG
+# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #953

### Motivation

Some sources use wrong license header.

### Modifications

PR updates the headers to use `Siemens Healthineers AG` instead of `Siemens Healthcare AG`.

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->