### PR TITLE
Consolidated Debian Changes

### DIFF
--- a/lib/modules/k2s/k2s.cluster.module/setup/setupcluster.module.psm1
+++ b/lib/modules/k2s/k2s.cluster.module/setup/setupcluster.module.psm1
@@ -260,6 +260,8 @@ function Join-LinuxNode {
         $joinCommand = "sudo kubeadm join $apiServerEndpoint" + ' --node-name ' + $NodeName + ' --ignore-preflight-errors IsPrivilegedUser' + " --config `"$target`""
         Write-Log "Created join command: $joinCommand"
 
+        (Invoke-CmdOnVmViaSSHKey -CmdToExecute "sudo systemctl start crio" -UserName $NodeUserName -IpAddress $NodeIpAddress).Output | Write-Log
+        
         $job = Invoke-Expression "Start-Job -ScriptBlock `${Function:Wait-ForNodesReady} -ArgumentList $NodeName"
         Write-Log "Invoke join command in node '$NodeName'"
         (Invoke-CmdOnVmViaSSHKey -CmdToExecute $joinCommand -UserName $NodeUserName -IpAddress $NodeIpAddress).Output | Write-Log

--- a/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/NetplanK2s.yaml
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/NetplanK2s.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: © 2023 Siemens Healthcare GmbH
+#
+# SPDX-License-Identifier: MIT
+network:
+  ethernets:
+    __NETWORK_INTERFACE_NAME__:
+      addresses: [__NETWORK_ADDRESSES__]
+      dhcp4: false
+      mtu: 1400
+      routes:
+      - to: default
+        via: __IP_GATEWAY__
+      nameservers:
+        addresses: [__DNS_IP_ADDRESSES__]
+  version: 2

--- a/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/base-image.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/base-image.module.psm1
@@ -45,9 +45,9 @@ function Invoke-DownloadDebianImage {
         [string]$Proxy = ''
     )
 
-    $urlRoot = 'https://cloud.debian.org/images/cloud/bullseye/latest'
+    $urlRoot = 'https://cloud.debian.org/images/cloud/bookworm/latest/'
 
-    $urlFile = 'debian-11-genericcloud-amd64.qcow2'
+    $urlFile = 'debian-12-genericcloud-amd64.qcow2'
 
     $url = "$urlRoot/$urlFile"
 
@@ -212,7 +212,7 @@ Function New-IsoFile {
     $networkConfigFileContent = Get-Content -Path $networkConfigTemplateFilePath -Raw -ErrorAction Stop
     $networkConfigConversionTable = @{
         "__NETWORK_INTERFACE_NAME__"=$IsoContentParameterValue.NetworkInterfaceName
-        "__IP_ADDRESS_VM__"=$IsoContentParameterValue.IPAddressVM
+        "__IP_ADDRESS_VM__"="$($IsoContentParameterValue.IPAddressVM)/24"
         "__IP_ADDRESS_GATEWAY__"=$IsoContentParameterValue.IPAddressGateway
         "__IP_ADDRESSES_DNS_SERVERS__"=$IsoContentParameterValue.IPAddressDnsServers
     }

--- a/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/cloud-init-templates/network-config
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/cloud-init-templates/network-config
@@ -3,7 +3,9 @@ ethernets:
   __NETWORK_INTERFACE_NAME__:
     dhcp4: false
     addresses: [__IP_ADDRESS_VM__]
-    gateway4: __IP_ADDRESS_GATEWAY__
+    routes:
+        - to: default
+          via: __IP_ADDRESS_GATEWAY__
     nameservers:
       addresses: [__IP_ADDRESSES_DNS_SERVERS__]
     mtu: 1400

--- a/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/cloud-init-templates/user-data
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/cloud-init-templates/user-data
@@ -13,8 +13,7 @@ users:
     no_user_group: true
     primary_group: users
     sudo: ALL=(ALL) NOPASSWD:ALL
-    groups: users, admin, docker, sudo, debian, adm, netdev
-    ssh_import_id: None
+    groups: users, admin, docker, sudo, adm, netdev    
     lock_passwd: false 
     plain_text_passwd: __VM_USER_PWD__
     ssh_authorized_keys:
@@ -26,5 +25,5 @@ apt:
 
 runcmd:
 - rm /etc/resolv.conf && echo "nameserver __IP_ADDRESSES_DNS_SERVERS__" > /etc/resolv.conf && chattr +i /etc/resolv.conf
-- /etc/init.d/networking restart
+- netplan apply
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/provisioning.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/provisioning.module.psm1
@@ -217,16 +217,16 @@ function New-KubemasterBaseImage {
         (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo sed -i `"s/$(Get-HostnameForProvisioningKubeNode)/$hostnameKubemaster/g`" /etc/hosts" -RemoteUser $remoteUser1).Output | Write-Log
 
         # IP
-        $interfaceConfigurationPath = '/etc/network/interfaces.d/10-k2s'
-        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo auto lo | sudo tee $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo iface lo inet loopback | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo auto $InterfaceName | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo iface $InterfaceName inet static | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo address $IpAddress/24 | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo dns-nameservers $($DnsServers.Replace(',', ' ')) | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo gateway $GatewayIpAddress | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo mtu 1400 | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-        (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo rm -f /etc/network/interfaces.d/50-cloud-init" -RemoteUser $remoteUser1).Output | Write-Log
+        $interfaceConfigurationPath = '/etc/netplan/10-k2s.yaml'
+        $configPath = "$PSScriptRoot\NetplanK2s.yaml"
+        $netplanConfigurationTemplate = Get-Content $configPath
+        $netplanConfiguration = $netplanConfigurationTemplate.Replace("__NETWORK_INTERFACE_NAME__",$InterfaceName).Replace("__NETWORK_ADDRESSES__","$IpAddress/24").Replace("__IP_GATEWAY__", $GatewayIpAddress).Replace("__DNS_IP_ADDRESSES__",$DnsServers)
+        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo '' | sudo tee $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
+        foreach ($line in $netplanConfiguration) {
+            (Invoke-CmdOnControlPlaneViaUserAndPwd "echo '$line' | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
+        }
+        (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo chmod 600 $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
+        (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo rm -f /etc/netplan/50-cloud-init.yaml" -RemoteUser $remoteUser1).Output | Write-Log
 
         # ssh keys
         (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo rm -f /etc/ssh/ssh_host_*; sudo ssh-keygen -A; sudo systemctl restart ssh" -RemoteUser $remoteUser1).Output | Write-Log
@@ -360,16 +360,16 @@ function New-KubeworkerBaseImage {
     (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo sed -i `"s/$(Get-HostnameForProvisioningKubeNode)/$Hostname/g`" /etc/hosts" -RemoteUser $remoteUser1).Output | Write-Log
 
     # IP
-    $interfaceConfigurationPath = '/etc/network/interfaces.d/10-k2s'
-    (Invoke-CmdOnControlPlaneViaUserAndPwd "echo auto lo | sudo tee $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaUserAndPwd "echo iface lo inet loopback | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaUserAndPwd "echo auto $InterfaceName | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaUserAndPwd "echo iface $InterfaceName inet static | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaUserAndPwd "echo address $IpAddress/24 | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaUserAndPwd "echo dns-nameservers $($DnsServers.Replace(',', ' ')) | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaUserAndPwd "echo gateway $GatewayIpAddress | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaUserAndPwd "echo mtu 1400 | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo rm -f /etc/network/interfaces.d/50-cloud-init" -RemoteUser $remoteUser1).Output | Write-Log
+    $interfaceConfigurationPath = '/etc/netplan/10-k2s.yaml'
+    $configPath = "$PSScriptRoot\NetplanK2s.yaml"
+    $netplanConfigurationTemplate = Get-Content $configPath
+    $netplanConfiguration = $netplanConfigurationTemplate.Replace("__NETWORK_INTERFACE_NAME__",$InterfaceName).Replace("__NETWORK_ADDRESSES__","$IpAddress/24").Replace("__IP_GATEWAY__", $GatewayIpAddress).Replace("__DNS_IP_ADDRESSES__",$DnsServers)
+    (Invoke-CmdOnControlPlaneViaUserAndPwd "echo '' | sudo tee $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
+    foreach ($line in $netplanConfiguration) {
+        (Invoke-CmdOnControlPlaneViaUserAndPwd "echo '$line' | sudo tee -a $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
+    }
+    (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo chmod 600 $interfaceConfigurationPath" -RemoteUser $remoteUser1).Output | Write-Log
+    (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo rm -f /etc/netplan/50-cloud-init.yaml" -RemoteUser $remoteUser1).Output | Write-Log
 
     # ssh keys
     (Invoke-CmdOnControlPlaneViaUserAndPwd "sudo rm -f /etc/ssh/ssh_host_*; sudo ssh-keygen -A; sudo systemctl restart ssh" -RemoteUser $remoteUser1).Output | Write-Log

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
@@ -281,9 +281,9 @@ function Start-ControlPlaneNodeOnNewVM {
 
     Invoke-TimeSync
 
-    Write-Log 'Set the DNS server(s) used by the Windows Host as the default DNS server(s) of the VM'
-    (Invoke-CmdOnControlPlaneViaSSHKey "sudo sed -i 's/dns-nameservers.*/dns-nameservers $DnsServers/' /etc/network/interfaces.d/10-k2s").Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaSSHKey 'sudo systemctl restart networking').Output | Write-Log
+    Write-Log 'Set the DNS server(s) used by the Windows Host as the default DNS server(s) of the VM'    
+    (Invoke-CmdOnControlPlaneViaSSHKey "sudo sed -i '/nameservers:/!b;n;s/addresses: \[.*\]/addresses: [$DnsServers]/' /etc/netplan/10-k2s.yaml").Output | Write-Log    
+    (Invoke-CmdOnControlPlaneViaSSHKey 'sudo systemctl restart systemd-networkd').Output | Write-Log
     (Invoke-CmdOnControlPlaneViaSSHKey 'sudo systemctl restart dnsmasq').Output | Write-Log
 
     $ipControlPlane = Get-ConfiguredIPControlPlane

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/worker-node.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/worker-node.module.psm1
@@ -66,8 +66,8 @@ function Add-LinuxWorkerNodeOnNewVM {
     Copy-LocalPublicSshKeyToRemoteComputer -UserName $remoteUsername -UserPwd $remoteUserPwd -IpAddress $IpAddress
     Wait-ForSSHConnectionToLinuxVMViaSshKey -User $remoteUser
 
-    (Invoke-CmdOnVmViaSSHKey "sudo sed -i 's/dns-nameservers.*/dns-nameservers $(Get-ConfiguredIPControlPlane)/' /etc/network/interfaces.d/10-k2s" -IpAddress $IpAddress).Output | Write-Log
-    (Invoke-CmdOnVmViaSSHKey 'sudo systemctl restart networking' -IpAddress $IpAddress).Output | Write-Log
+    (Invoke-CmdOnVmViaSSHKey "sudo sed -i '/nameservers:/!b;n;s/addresses: \[.*\]/addresses: [$(Get-ConfiguredIPControlPlane)]/' /etc/netplan/10-k2s.yaml" -IpAddress $IpAddress).Output | Write-Log
+    (Invoke-CmdOnVmViaSSHKey 'sudo systemctl restart systemd-networkd' -IpAddress $IpAddress).Output | Write-Log
 
     Join-LinuxNode -NodeName $WorkerNodeName -NodeUserName $remoteUsername -NodeIpAddress $IpAddress
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
@@ -525,7 +525,7 @@ function Wait-ForSshPossible {
             }
         }
         else {
-            $result = $(Write-Output yes | &"$plinkExe" -ssh -4 $User -pw $UserPwd -no-antispoof "$($SshTestCommand)" 2>&1)
+            $result = $(Write-Output y | &"$plinkExe" -ssh -4 $User -pw $UserPwd -no-antispoof "$($SshTestCommand)" 2>&1)
         }
 
         if ($StrictEqualityCheck -eq $true) {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

[Fixes #TODO](https://github.com/Siemens-Healthineers/K2s/issues/649)

### Motivation

Upgrade to Debian 12 as Debian 11 would reach EOL soon.

### Modifications

1. lib/modules/k2s/k2s.cluster.module/setup/setupcluster.module.psm1 --> Start crio explicitly as it takes time to get started on VM reboot.
2. lib/modules/k2s/k2s.node.module/linuxnode/baseimage/NetplanK2s.yaml --> New Netplan configuration file with required parameters.
3. lib/modules/k2s/k2s.node.module/linuxnode/baseimage/base-image.module.psm1 --> Using new Linux12 OS instead of Linux 11 and had to specify the subnet additionally, if not the IP address would not be set for the VM created.
4. lib/modules/k2s/k2s.node.module/linuxnode/baseimage/cloud-init-templates/network-config --> Adapting to newer configuration.
5. lib/modules/k2s/k2s.node.module/linuxnode/baseimage/cloud-init-templates/user-data --> Switched to netplan apply which is the network management system for Debian 12 instead of old one. Got rid of ssh_import_id: None8 which was causing delay in connecting to VM from host machine.
6. lib/modules/k2s/k2s.node.module/linuxnode/baseimage/provisioning.module.psm1 --> The new way of reading/setting IP address for Debian 12.
7. lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1 --> Adding hostname to /etc/hosts and stop systemd-resolved before making DNS changes.
8. lib/modules/k2s/k2s.node.module/linuxnode/setup/control-plane-node.module.psm1
9. lib/modules/k2s/k2s.node.module/linuxnode/setup/worker-node.module.psm1 --> Add nameserver information to /etc/netplan/10-k2s.yaml that is looked upon by network management system of Debian 12.
10. lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1 --> Changed to y instead of "yes" , without this change we were not able to connect to the installed VM from host machine, especially on test agent machines.


### Verification

1. Local installation of K2s works fine including linux--only use case also.
2.  Tested some addons also work fine.
3.  Performed Start and stop of K2s and that also works fine.
4.  Builds queued on the private branch(Debian12Latest) works fine except for multivm scenario which seem to be a general issue and nothing to do with the Debian changes.

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->