### PR TITLE
#907: fixes issue of dnsmasq not being available in wsl mode

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -1041,27 +1041,27 @@ Function Add-SupportForWSL {
 
     # WSL2 config
     Write-Log 'Configure WSL2'
-    &$executeRemoteCommand 'sudo touch /etc/wsl.conf'
-    &$executeRemoteCommand 'echo [automount] | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand 'echo enabled = false | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand "echo -e 'mountFsTab = false\n' | sudo tee -a /etc/wsl.conf"
+    &$executeRemoteCommand "sudo touch $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo [automount] | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo enabled = false | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo -e 'mountFsTab = false\n' | sudo tee -a $wslConfigurationFilePath"
 
-    &$executeRemoteCommand 'echo [interop] | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand 'echo enabled = false | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand "echo -e 'appendWindowsPath = false\n' | sudo tee -a /etc/wsl.conf"
+    &$executeRemoteCommand "echo [interop] | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo enabled = false | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo -e 'appendWindowsPath = false\n' | sudo tee -a $wslConfigurationFilePath"
 
-    &$executeRemoteCommand 'echo [user] | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand "echo -e 'default = __USERNAME__\n' | sudo tee -a /etc/wsl.conf"
+    &$executeRemoteCommand "echo [user] | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo -e 'default = __USERNAME__\n' | sudo tee -a $wslConfigurationFilePath"
 
-    &$executeRemoteCommand 'echo [network] | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand 'echo generateHosts = false | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand 'echo generateResolvConf = false | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand 'echo hostname = __HOSTNAME__ | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand 'echo | sudo tee -a /etc/wsl.conf'
+    &$executeRemoteCommand "echo [network] | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo generateHosts = false | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo generateResolvConf = false | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo hostname = __HOSTNAME__ | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo | sudo tee -a $wslConfigurationFilePath"
 
-    &$executeRemoteCommand 'echo [boot] | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand 'echo systemd = true | sudo tee -a /etc/wsl.conf'
-    &$executeRemoteCommand "echo 'command = ""sudo ifconfig __INTERFACE_NAME__ __IP_ADDRESS__ && sudo ifconfig __INTERFACE_NAME__ netmask __NETWORK_MASK__"" && sudo route add default gw __GATEWAY_IP_ADDRESS__' | sudo tee -a /etc/wsl.conf"
+    &$executeRemoteCommand "echo [boot] | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo systemd = true | sudo tee -a $wslConfigurationFilePath"
+    &$executeRemoteCommand "echo 'command = ""sudo ifconfig __INTERFACE_NAME__ __IP_ADDRESS__ && sudo ifconfig __INTERFACE_NAME__ netmask __NETWORK_MASK__"" && sudo route add default gw __GATEWAY_IP_ADDRESS__' | sudo tee -a $wslConfigurationFilePath"
 }
 
 function Edit-SupportForWSL {

--- a/lib/modules/k2s/k2s.node.module/windowsnode/system/system.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/windowsnode/system/system.module.psm1
@@ -56,7 +56,7 @@ function Enable-MissingFeature {
 function Enable-MissingWindowsFeatures($wsl) {
     $restartRequired = $false
 
-    $isServerOS = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ProductName.Contains("Server")
+    $isServerOS = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ProductName.Contains('Server')
 
     $features = @('Microsoft-Hyper-V', 'Microsoft-Hyper-V-Management-PowerShell', 'Containers', 'VirtualMachinePlatform')
 
@@ -116,6 +116,9 @@ function Set-WSL {
 swap=0
 memory=$MasterVMMemory
 processors=$MasterVMProcessorCount
+localhostForwarding=false
+dnsProxy=false
+dnsTunneling=false
 "@
     $wslConfig | Out-File -FilePath $wslConfigPath
 }
@@ -123,8 +126,7 @@ processors=$MasterVMProcessorCount
 
 function Test-WindowsPrerequisites(
     [parameter(Mandatory = $false, HelpMessage = 'Use WSL2 for hosting control plane VM (Linux)')]
-    [switch] $WSL = $false)
-{
+    [switch] $WSL = $false) {
     Add-K2sToDefenderExclusion
     Stop-InstallIfDockerDesktopIsRunning
 
@@ -250,14 +252,14 @@ function Stop-InstallationIfRequiredCurlVersionNotInstalled {
         throw $errorMessage
     }
 
-    $minimumRequiredVersion = [Version]"7.71.0"
+    $minimumRequiredVersion = [Version]'7.71.0'
 
     if ($actualVersion -lt $minimumRequiredVersion) {
         $errorMessage = ("[PREREQ-FAILED] The installed version of 'curl' ($actualVersionAsString) is not at least the required one ($($minimumRequiredVersion.ToString())).",
-        "`n",
-        "Call 'curl.exe --version' to check the installed version.",
-        "`n",
-        "Update 'curl' and add its installation location to the 'PATH' environment variable.")
+            "`n",
+            "Call 'curl.exe --version' to check the installed version.",
+            "`n",
+            "Update 'curl' and add its installation location to the 'PATH' environment variable.")
         Write-Log $errorMessage
         throw $errorMessage
     }
@@ -265,7 +267,7 @@ function Stop-InstallationIfRequiredCurlVersionNotInstalled {
 
 function Write-WarningIfRequiredSshVersionNotInstalled {
     try {
-        $sshPath = (Get-Command "ssh.exe").Path
+        $sshPath = (Get-Command 'ssh.exe').Path
         $majorVersion = (Get-Item $sshPath).VersionInfo.FileVersionRaw.Major
         $fileVersion = (Get-Item $sshPath).VersionInfo.FileVersion
     }
@@ -277,8 +279,8 @@ function Write-WarningIfRequiredSshVersionNotInstalled {
 
     if ($majorVersion -lt 8) {
         $warnMessage = "[PREREQ-WARNING] The installed version of 'ssh' ($fileVersion) is not at least the required one (major version 8). " `
-        + "Call 'ssh.exe -V' to check the installed version. " `
-        + "Update 'ssh' and add its installation location to the 'PATH' environment variable to ensure successful cluster installation."
+            + "Call 'ssh.exe -V' to check the installed version. " `
+            + "Update 'ssh' and add its installation location to the 'PATH' environment variable to ensure successful cluster installation."
 
         Write-Log $warnMessage
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #907 

### Motivation
If K2s is installed with `--wsl`, the `dnsmasq` service cannot be started because `port 53` is already in use

### Modifications
Disable the following options in the .wslconfig file of the user:

```cmd
localhostForwarding=false
dnsProxy=false
dnsTunneling=false
```

### Verification

Existing WSL tests are passing

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->