### PR TITLE
Change to preserve kubernetes artifacts version #990

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -262,6 +262,8 @@ Function Get-KubernetesArtifactsFromInternet {
     &$downloadPackagesCommand -PackageName "kubectl=$shortKubeVers" -DebFileNamePattern 'kubectl*.deb'
     &$downloadPackagesCommand -PackageName "kubelet=$shortKubeVers" -DebFileNamePattern 'kubelet*.deb'
     &$downloadPackagesCommand -PackageName "kubeadm=$shortKubeVers" -DebFileNamePattern 'kubeadm*.deb'
+
+    &$executeRemoteCommand "cd /home/remote/apt-offline-k2s/kubernetes && sudo find . -maxdepth 1 -type f \( -name 'kubeadm_*.deb' -o -name 'kubectl_*.deb' -o -name 'kubelet_*.deb' \) ! -name '*_${shortKubeVers}_amd64.deb' -exec rm -f {} +"
 }
 
 Function Add-KubernetesArtifactsToRemoteComputer {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

The changes fix the issue #990

### Motivation

The changes would make sure that Kubernetes artifacts like kubectl, kubeadm, kubelet versions remain the same as K8s version

### Modifications

Tried out many other possibilities to restrict the download but that does not seem to work.
So the approach taken to fix the issue was to delete the additional packages that are downloaded to avoid the installation.

### Verification

<!-- TODO: Say how you tested your changes. -->
Verified by running the K2s installation locally.
Triggered builds in agro CD workflows which ran green.
<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->