### PR TITLE
Fetching ID to make language independent : Fix for issue https://github.com/Siemens-Healthineers/K2s/issues/964

### DIFF
--- a/lib/modules/k2s/k2s.cluster.module/system/system.module.psm1
+++ b/lib/modules/k2s/k2s.cluster.module/system/system.module.psm1
@@ -18,7 +18,7 @@ $kubeToolsPath = Get-KubeToolsPath
 Performs time synchronization across all nodes of the clusters.
 #>
 function Invoke-TimeSync {
-    $timezoneStandardNameOnHost = (Get-TimeZone).StandardName
+    $timezoneStandardNameOnHost = (Get-TimeZone).Id
     $kubeConfigDir = Get-ConfiguredKubeConfigDir
     $windowsTimezoneConfig = "$kubeConfigDir\windowsZones.xml"
     [XML]$timezoneConfigXml = (Get-Content -Path $windowsTimezoneConfig)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

The PR is to fix the issue that time zone mapping is not working when language on windows machine is changed to something other than English

### Motivation

Change to fix Linux time zone issue

### Modifications

Getting (Get-TimeZone).Id instead of StandardName

### Verification

Verified by installing K2s on windows machine that has Slovakian language and we were able to set the time zone on Linux machine.

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->