### PR TITLE
Fixed export of windows-exporter image for offline usecase

### DIFF
--- a/addons/Export.ps1
+++ b/addons/Export.ps1
@@ -336,20 +336,18 @@ try {
 
                 Write-Log "Exporting images for addon $addonName" -Console
 
-                $exportImageScript = "$PSScriptRoot\..\lib\scripts\k2s\image\Export-Image.ps1"
                 $count = 0
-                
-                # Export Linux images
-                foreach ($image in $linuxImages) {
-                    Write-Log "Processing Linux image: $image"
+                foreach ($image in $images) {
+                    Write-Log $image
                     $imageNameWithoutTag = ($image -split ':')[0]
                     $imageTag = ($image -split ':')[1]
                     $linuxImageToExportArray = @($linuxContainerImages | Where-Object { $_.Repository -match ".*${imageNameWithoutTag}$" -and $_.Tag -eq $imageTag })
+                    $windowsImageToExportArray = @($windowsContainerImages | Where-Object { $_.Repository -match ".*${imageNameWithoutTag}$" -and $_.Tag -eq $imageTag })
+                    $exportImageScript = "$PSScriptRoot\..\lib\scripts\k2s\image\Export-Image.ps1"
                     
                     if ($linuxImageToExportArray -and $linuxImageToExportArray.Count -gt 0) {
                         $imageToExport = $linuxImageToExportArray[0]
-                        $imageFullName = "$($imageToExport.Repository):$($imageToExport.Tag)"
-                        &$exportImageScript -Name $imageFullName -ExportPath "${tmpExportDir}\addons\$dirName\${count}.tar" -ShowLogs:$ShowLogs
+                        &$exportImageScript -Id $imageToExport.ImageId -ExportPath "${tmpExportDir}\addons\$dirName\${count}.tar" -ShowLogs:$ShowLogs
 
                         if (!$?) {
                             $errMsg = "Image $imageNameWithoutTag could not be exported."
@@ -365,19 +363,10 @@ try {
 
                         $count += 1
                     }
-                }
 
-                # Export Windows images
-                foreach ($image in $windowsImages) {
-                    Write-Log "Processing Windows image: $image"
-                    $imageNameWithoutTag = ($image -split ':')[0]
-                    $imageTag = ($image -split ':')[1]
-                    $windowsImageToExportArray = @($windowsContainerImages | Where-Object { $_.Repository -match ".*${imageNameWithoutTag}$" -and $_.Tag -eq $imageTag })
-                    
                     if ($windowsImageToExportArray -and $windowsImageToExportArray.Count -gt 0) {
                         $imageToExport = $windowsImageToExportArray[0]
-                        $imageFullName = "$($imageToExport.Repository):$($imageToExport.Tag)"
-                        &$exportImageScript -Name $imageFullName -ExportPath "${tmpExportDir}\addons\$dirName\${count}_win.tar" -ShowLogs:$ShowLogs
+                        &$exportImageScript -Id $imageToExport.ImageId -ExportPath "${tmpExportDir}\addons\$dirName\${count}_win.tar" -ShowLogs:$ShowLogs
 
                         if (!$?) {
                             $errMsg = "Image $imageNameWithoutTag could not be exported!"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes export-import testcase checking exporting windows exporter image for offline usecase

### Motivation

Testcase failure adaptation

### Modifications

Removed the version less windows exporter image picked from additional Images in addons manifest

### Verification

Existing e2e tests are running green now.

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->