### PR TITLE
Fixed path resolution of additional images in addons manifest 

### DIFF
--- a/addons/addons.module.psm1
+++ b/addons/addons.module.psm1
@@ -1155,7 +1155,12 @@ function Get-ImagesFromYamlFiles {
     $allImages = @()
     
     foreach ($yamlFile in $YamlFiles) {
-        $filePath = if ([System.IO.Path]::IsPathRooted($yamlFile)) { $yamlFile } else { Join-Path $BaseDirectory $yamlFile }
+        if ([System.IO.Path]::IsPathRooted($yamlFile)) {
+            $filePath = $yamlFile
+        } else {
+            $filePath = Join-Path $BaseDirectory $yamlFile
+            $filePath = [System.IO.Path]::GetFullPath($filePath)
+        }
         
         if (Test-Path $filePath) {
             Write-Log "Extracting images from $filePath"

--- a/build/bom/DumpK2sImages.ps1
+++ b/build/bom/DumpK2sImages.ps1
@@ -176,7 +176,7 @@ foreach ($manifest in $addonManifests) {
 
             # extract additionalImagesFiles if present
             if ($linuxPackages.additionalImagesFiles -and $linuxPackages.additionalImagesFiles.Count -gt 0) {
-                $extractedImages = Get-ImagesFromYamlFiles -YamlFiles $linuxPackages.additionalImagesFiles -BaseDirectory "$global:KubernetesPath\addons\"
+                $extractedImages = Get-ImagesFromYamlFiles -YamlFiles $linuxPackages.additionalImagesFiles -BaseDirectory $dirPath
                 if ($extractedImages.Count -gt 0) {
                     if (-not $addonNameImagesMapping.ContainsKey($addonName)) {
                         $addonNameImagesMapping[$addonName] = @()


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #1310 

### Motivation

Fixed issue with path resolution of additionalImageFiles reference in addons manifest

### Modifications

Fixed the path resolution of additional Images with GetFullPath and  dirPath

### Verification

Path must be correctly resolved now

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->