### PR TITLE
#1840 docs(proxy): add proxy configuration user guide

### DIFF
--- a/docs/user-guide/proxy-configuration.md
+++ b/docs/user-guide/proxy-configuration.md
@@ -61,7 +61,7 @@ Returns only the proxy URI (useful for scripting). If no proxy is configured, th
 
 ### Show proxy details
 
-Display the proxy URI together with all configured proxy overrides.
+Display the proxy URI together with the overrides stored in the proxy configuration.
 
 ```console
 k2s system proxy show
@@ -96,7 +96,9 @@ After resetting, the cluster accesses external networks directly (or via NAT, de
 
 ## Proxy Overrides (No-Proxy)
 
-Proxy overrides define destinations that should bypass the proxy and be reached directly. *K2s* automatically includes internal cluster addresses (e.g., the control-plane IP, pod/service CIDRs) — you do not need to add these manually.
+Proxy overrides define destinations that should bypass the proxy and be reached directly.
+
+*K2s* internally manages additional bypass entries (e.g., the control-plane IP, pod/service CIDRs) to ensure cluster components can communicate without going through the proxy. These internal entries are applied automatically and do not appear in the `override` commands.
 
 Use overrides for additional hosts or domains that should not go through the proxy, such as internal registries, artifact servers, or local services.
 
@@ -139,7 +141,7 @@ k2s system proxy override delete registry.internal.example.com
 k2s system proxy override ls
 ```
 
-Lists all currently configured proxy overrides, including both user-added and auto-generated K2s internal entries.
+Lists the proxy overrides currently stored in the proxy configuration.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG
+# SPDX-FileCopyrightText: © 2026 Siemens Healthineers AG
 # SPDX-License-Identifier: MIT
 
 site_name: K2s - Kubernetes distribution for Windows & Linux workloads


### PR DESCRIPTION
Fixes #1840

### Motivation

The `k2s system proxy` commands (set, get, show, reset, override add/delete/ls) had no user-facing documentation. Users had to discover proxy workflows through CLI help text alone.

### Modifications

- `docs/user-guide/proxy-configuration.md` — New user guide covering:
  - How the proxy architecture works (httpproxy service, Linux VM APT/CRI-O/Buildah configuration)
  - All proxy commands: `set`, `get`, `show`, `reset`
  - Proxy override (no-proxy) management: `override add`, `override delete`, `override ls`
  - A typical workflow example
  - Tip about resetting proxy before offline packaging
  - Mermaid architecture diagram
- `mkdocs.yml` — Added "Proxy Configuration" nav entry under User Guide; fixed SPDX copyright year (2024 → 2026)

### Verification

- Content reviewed against the CLI implementation (Go handlers + PowerShell scripts)
- Wording verified to accurately reflect persisted-config semantics for `show` and `override ls`