### PR TITLE
fix(build-image, security): fix flaky e2e tests due to nginx webhook unavailability and postgresql pod timeout

### DIFF
--- a/addons/security/security.module.psm1
+++ b/addons/security/security.module.psm1
@@ -215,7 +215,7 @@ function Wait-ForKeyCloakAvailable($waiTime = 240) {
 .DESCRIPTION
 Waits for the keycloak postgresqlpods to be available.
 #>
-function Wait-ForKeyCloakPostgresqlAvailable($waiTime = 240) {
+function Wait-ForKeyCloakPostgresqlAvailable($waiTime = 360) {
     return (Wait-ForPodCondition -Condition Ready -Label 'app=postgresql' -Namespace 'security' -TimeoutSeconds $waiTime)
 }
 

--- a/k2s/test/e2e/addons/generic/build_image/build_image_test.go
+++ b/k2s/test/e2e/addons/generic/build_image/build_image_test.go
@@ -334,7 +334,7 @@ func deployWithImage(ctx context.Context, srcPath, name, deploymentName string) 
 	Eventually(func(g Gomega) {
 		_, exitCode := suite.Kubectl().Exec(ctx, "apply", "-f", filepath.Join(srcPath, "ing-nginx.yaml"))
 		g.Expect(exitCode).To(Equal(0))
-	}).WithContext(ctx).WithTimeout(3 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
+	}).WithContext(ctx).WithTimeout(5 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
 
 	suite.Kubectl().MustExec(ctx, "set", "image", deploymentLabel, newImageName)
 	suite.Kubectl().MustExec(ctx, "rollout", "restart", deploymentLabel)
@@ -344,7 +344,6 @@ func deployWithImage(ctx context.Context, srcPath, name, deploymentName string) 
 }
 
 func deleteDeployment(ctx context.Context, srcDirName, deploymentName string) {
-	suite.Kubectl().Exec(ctx, "delete", "-f", filepath.Join(srcDirName, "ing-nginx.yaml"))
 	suite.Kubectl().Exec(ctx, "delete", "-f", filepath.Join(srcDirName, "weather.yaml"))
 
 	suite.Cluster().ExpectDeploymentToBeRemoved(ctx, labelName, deploymentName, namespace)

--- a/k2s/test/e2e/addons/generic/build_image/build_image_test.go
+++ b/k2s/test/e2e/addons/generic/build_image/build_image_test.go
@@ -327,7 +327,12 @@ func deployWithImage(ctx context.Context, srcPath, name, deploymentName string) 
 	deploymentLabel := fmt.Sprintf("deployment/%s", deploymentName)
 	newImageName := fmt.Sprintf("%s=%s", deploymentName, name)
 
-	suite.Kubectl().MustExec(ctx, "apply", "-f", filepath.Join(srcPath, "weather.yaml"))
+	// Retry weather.yaml apply to handle transient kube-apiserver unavailability
+	// (can occur after heavy k2s image rm workload stresses the API server).
+	Eventually(func(g Gomega) {
+		_, exitCode := suite.Kubectl().Exec(ctx, "apply", "-f", filepath.Join(srcPath, "weather.yaml"))
+		g.Expect(exitCode).To(Equal(0))
+	}).WithContext(ctx).WithTimeout(5 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
 
 	// Retry ing-nginx.yaml apply to handle transient nginx admission webhook unavailability
 	// between test specs (webhook can take several minutes to recover after ingress deletion).

--- a/k2s/test/e2e/addons/generic/build_image/build_image_test.go
+++ b/k2s/test/e2e/addons/generic/build_image/build_image_test.go
@@ -328,7 +328,13 @@ func deployWithImage(ctx context.Context, srcPath, name, deploymentName string) 
 	newImageName := fmt.Sprintf("%s=%s", deploymentName, name)
 
 	suite.Kubectl().MustExec(ctx, "apply", "-f", filepath.Join(srcPath, "weather.yaml"))
-	suite.Kubectl().MustExec(ctx, "apply", "-f", filepath.Join(srcPath, "ing-nginx.yaml"))
+
+	// Retry ing-nginx.yaml apply to handle transient nginx admission webhook unavailability
+	// between test specs (webhook can take several minutes to recover after ingress deletion).
+	Eventually(func(g Gomega) {
+		_, exitCode := suite.Kubectl().Exec(ctx, "apply", "-f", filepath.Join(srcPath, "ing-nginx.yaml"))
+		g.Expect(exitCode).To(Equal(0))
+	}).WithContext(ctx).WithTimeout(3 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
 
 	suite.Kubectl().MustExec(ctx, "set", "image", deploymentLabel, newImageName)
 	suite.Kubectl().MustExec(ctx, "rollout", "restart", deploymentLabel)


### PR DESCRIPTION
Fixes #TODO

### Motivation

The `build-image` e2e test suite was failing intermittently on Win11 CI runs with two error variants:

- `failed calling webhook &#34;validate.nginx.ingress.kubernetes.io&#34;: ... connection refused`
- `failed calling webhook &#34;validate.nginx.ingress.kubernetes.io&#34;: ... context deadline exceeded`
- `wsarecv: An existing connection was forcibly closed by the remote host` (kube-apiserver transient unavailability)

Root cause 1: the `deleteDeployment` cleanup between `When` blocks was deleting the ingress resource, which disrupted the nginx admission webhook pod. The webhook could take 12+ minutes to recover, and the next `When` block&#39;s `kubectl apply -f ing-nginx.yaml` would hit the webhook in a broken state and fail immediately, cascading into 16+ skipped specs.

Root cause 2: the heavy workload of `k2s image rm` stopping many pods in sequence temporarily stresses the kube-apiserver, causing transient unavailability for the subsequent `kubectl apply -f weather.yaml`.

Root cause 3 (ingress-nginx security-enhanced test): on resource-constrained CI machines, cert-manager startup takes 3–4 minutes instead of ~1 minute, which exhausts the 240s `postgresql` pod readiness timeout before the pod can reach Ready state. Additionally, `Wait-ForPodCondition` burns 2s per retry while waiting for the pod to be scheduled, further reducing the effective `kubectl wait --timeout` window.

### Modifications

- `k2s/test/e2e/addons/generic/build_image/build_image_test.go` — removed ingress deletion from `deleteDeployment()`. The ingress is identical across all Linux `When` blocks and the Windows ingress coexists independently, so leaving them alive between blocks causes no interference.
- `k2s/test/e2e/addons/generic/build_image/build_image_test.go` — wrapped `kubectl apply -f ing-nginx.yaml` in `Eventually` with 5-minute timeout and 15-second polling as a safety net for residual webhook unavailability.
- `k2s/test/e2e/addons/generic/build_image/build_image_test.go` — wrapped `kubectl apply -f weather.yaml` in `Eventually` with 5-minute timeout and 15-second polling to handle transient kube-apiserver unavailability after heavy image removal workload.
- `addons/security/security.module.psm1` — increased `Wait-ForKeyCloakPostgresqlAvailable` default timeout from 240s to 360s to give the postgresql pod sufficient time to become Ready on slow CI machines.

### Verification

- Confirmed fix compiles cleanly (`go build ./test/e2e/addons/generic/build_image/...`)
- Root cause 1 verified across 5 CI runs showing consistent webhook failure pattern after ingress deletion
- Root cause 2 identified from CI run showing API server connection refused immediately after `k2s image rm` bulk pod stopping
- Root cause 3 diagnosed from Ingress Nginx CI log: cert-manager took ~4.5 min, postgresql pod timed out after 240s (`postgresql-57d9464f48-c8gmf` on CIBOX11-0925, 2026-04-13)
- Full e2e run on CI