### PR TITLE
fix - monitoring addon grafana image pull.

### DIFF
--- a/addons/monitoring/Enable.ps1
+++ b/addons/monitoring/Enable.ps1
@@ -113,7 +113,7 @@ $windowsExporterPath = "$PSScriptRoot\..\common\manifests\windows-exporter"
 (Invoke-Kubectl -Params 'apply', '-k', $windowsExporterPath).Output | Write-Log
 
 Write-Log 'Waiting for Pods..'
-$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'deployments', '-n', 'monitoring', '--timeout=300s')
+$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'deployments', '-n', 'monitoring', '--timeout=600s')
 Write-Log $kubectlCmd.Output
 if (!$kubectlCmd.Success) {
     $errMsg = 'Kube Prometheus Stack could not be deployed!'
@@ -126,7 +126,7 @@ if (!$kubectlCmd.Success) {
     Write-Log $errMsg -Error
     exit 1
 }
-$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'daemonsets', '-n', 'monitoring', '--timeout=300s')
+$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'daemonsets', '-n', 'monitoring', '--timeout=600s')
 Write-Log $kubectlCmd.Output
 if (!$kubectlCmd.Success) {
     $errMsg = 'Kube Prometheus Stack could not be deployed!'
@@ -166,7 +166,7 @@ if ($allPodsAreUp -ne $true) {
     exit 1  
 }
 
-$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'statefulsets', '-n', 'monitoring', '--timeout=300s')
+$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'statefulsets', '-n', 'monitoring', '--timeout=600s')
 Write-Log $kubectlCmd.Output
 if (!$kubectlCmd.Success) {
     $errMsg = 'Kube Prometheus Stack could not be deployed!'

--- a/addons/monitoring/addon.manifest.yaml
+++ b/addons/monitoring/addon.manifest.yaml
@@ -16,10 +16,10 @@ spec:
           repos: []
           deb: []
           curl: []
-          additionalImages:
-            - quay.io/prometheus-operator/prometheus-config-reloader
+          additionalImages: []
           additionalImagesFiles:
             - manifests/monitoring/prometheus-operator/deployment.yaml
+            - manifests/monitoring/grafana/deployment.yaml
         windows:
           curl: []
           additionalImages:

--- a/addons/monitoring/manifests/monitoring/grafana/deployment.yaml
+++ b/addons/monitoring/manifests/monitoring/grafana/deployment.yaml
@@ -146,6 +146,7 @@ spec:
             httpGet:
               path: /api/health
               port: 3000
+            initialDelaySeconds: 60
       volumes:
         - name: config
           configMap:

--- a/build/bom/merge/k2s-static.json
+++ b/build/bom/merge/k2s-static.json
@@ -603,6 +603,213 @@
       "type": "application"
     },
     {
+      "group": "https://github.com/prometheus-operator/prometheus-operator",
+      "name": "prometheus-operator",
+      "version": "v0.90.1",
+      "description": "Kubernetes operator for Prometheus - monitoring addon",
+      "scope": "optional",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://github.com/prometheus-operator/prometheus-operator/blob/main/LICENSE"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sw360:projectName",
+          "value": "k2s:addon:monitoring"
+        }
+      ],
+      "purl": "pkg:github/prometheus-operator/prometheus-operator@v0.90.1",
+      "type": "container"
+    },
+    {
+      "group": "https://github.com/prometheus-operator/prometheus-operator",
+      "name": "prometheus-config-reloader",
+      "version": "v0.90.1",
+      "description": "Config reloader sidecar for Prometheus Operator - monitoring addon",
+      "scope": "optional",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://github.com/prometheus-operator/prometheus-operator/blob/main/LICENSE"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sw360:projectName",
+          "value": "k2s:addon:monitoring"
+        }
+      ],
+      "purl": "pkg:github/prometheus-operator/prometheus-operator@v0.90.1",
+      "type": "container"
+    },
+    {
+      "group": "https://github.com/prometheus/prometheus",
+      "name": "prometheus",
+      "version": "v3.11.2",
+      "description": "Systems and service monitoring toolkit - monitoring addon",
+      "scope": "optional",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://github.com/prometheus/prometheus/blob/main/LICENSE"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sw360:projectName",
+          "value": "k2s:addon:monitoring"
+        }
+      ],
+      "purl": "pkg:github/prometheus/prometheus@v3.11.2",
+      "type": "container"
+    },
+    {
+      "group": "https://github.com/prometheus/alertmanager",
+      "name": "alertmanager",
+      "version": "v0.32.0",
+      "description": "Prometheus Alertmanager - monitoring addon",
+      "scope": "optional",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://github.com/prometheus/alertmanager/blob/main/LICENSE"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sw360:projectName",
+          "value": "k2s:addon:monitoring"
+        }
+      ],
+      "purl": "pkg:github/prometheus/alertmanager@v0.32.0",
+      "type": "container"
+    },
+    {
+      "group": "https://github.com/thanos-io/thanos",
+      "name": "thanos",
+      "version": "v0.41.0",
+      "description": "Highly available Prometheus with long-term storage - monitoring addon",
+      "scope": "optional",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://github.com/thanos-io/thanos/blob/main/LICENSE"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sw360:projectName",
+          "value": "k2s:addon:monitoring"
+        }
+      ],
+      "purl": "pkg:github/thanos-io/thanos@v0.41.0",
+      "type": "container"
+    },
+    {
+      "group": "https://github.com/kubernetes/kube-state-metrics",
+      "name": "kube-state-metrics",
+      "version": "v2.18.0",
+      "description": "Service that generates metrics about the state of Kubernetes objects - monitoring addon",
+      "scope": "optional",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://github.com/kubernetes/kube-state-metrics/blob/main/LICENSE"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sw360:projectName",
+          "value": "k2s:addon:monitoring"
+        }
+      ],
+      "purl": "pkg:github/kubernetes/kube-state-metrics@v2.18.0",
+      "type": "container"
+    },
+    {
+      "group": "https://github.com/prometheus/node_exporter",
+      "name": "node-exporter",
+      "version": "v1.11.0",
+      "description": "Prometheus exporter for machine metrics - monitoring addon",
+      "scope": "optional",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://github.com/prometheus/node_exporter/blob/master/LICENSE"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sw360:projectName",
+          "value": "k2s:addon:monitoring"
+        }
+      ],
+      "purl": "pkg:github/prometheus/node_exporter@v1.11.0",
+      "type": "container"
+    },
+    {
+      "group": "https://github.com/grafana/grafana",
+      "name": "grafana",
+      "version": "13.0.0",
+      "description": "Open-source analytics and monitoring platform - monitoring addon",
+      "scope": "optional",
+      "licenses": [
+        {
+          "license": {
+            "id": "AGPL-3.0-only",
+            "url": "https://github.com/grafana/grafana/blob/main/LICENSE"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sw360:projectName",
+          "value": "k2s:addon:monitoring"
+        }
+      ],
+      "purl": "pkg:github/grafana/grafana@13.0.0",
+      "type": "container"
+    },
+    {
+      "group": "https://github.com/kiwigrid/k8s-sidecar",
+      "name": "k8s-sidecar",
+      "version": "2.6.0",
+      "description": "Sidecar to collect config maps with a specified label from all namespaces - monitoring addon",
+      "scope": "optional",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://github.com/kiwigrid/k8s-sidecar/blob/master/LICENSE"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "sw360:projectName",
+          "value": "k2s:addon:monitoring"
+        }
+      ],
+      "purl": "pkg:github/kiwigrid/k8s-sidecar@2.6.0",
+      "type": "container"
+    },
+    {
       "group": "https://github.com/headlamp-k8s/headlamp",
       "name": "headlamp",
       "version": "v0.41.0",

--- a/k2s/test/e2e/addons/monitoring/monitoring_test.go
+++ b/k2s/test/e2e/addons/monitoring/monitoring_test.go
@@ -59,7 +59,9 @@ var _ = AfterEach(func() {
 var _ = Describe("'monitoring' addon", Ordered, func() {
 	When("no ingress controller is configured", func() {
 		AfterAll(func(ctx context.Context) {
-			portForwardingSession.Kill()
+			if portForwardingSession != nil {
+				portForwardingSession.Kill()
+			}
 			suite.K2sCli().MustExec(ctx, "addons", "disable", "monitoring", "-o")
 
 			k2s.VerifyAddonIsDisabled("monitoring")


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes monitoring addon nightly CI failures due to Grafana ImagePullBackOff

### Motivation

Grafana images missing from mirror registry shsk2s.azurecr.io causing pod pull failures.

### Modifications

Added grafana/deployment.yaml to additionalImagesFiles in addon.manifest.yaml
Added initialDelaySeconds: 60 to Grafana readinessProbe in deployment.yaml
Increased rollout timeouts from 300s to 600s in Enable.ps1
Fixed nil pointer panic on portForwardingSession.Kill() in monitoring_test.go

### Verification

Analyzed all 4 failed nightly CI run logs and confirmed root cause.

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->