### PR TITLE
2155 - Fixing APT proxy handling for node package downloads (K8s + buildah, Debian 12/13)

### DIFF
--- a/cfg/nodeextension/debian12/scripts/download-buildah-packages.sh
+++ b/cfg/nodeextension/debian12/scripts/download-buildah-packages.sh
@@ -11,8 +11,10 @@
 # Arguments:
 #   $1 - Target path on the remote machine to store downloaded .deb packages
 #        (e.g. /home/sk/apt-offline-k2s/buildah)
+#   $2 - Optional HTTP/HTTPS proxy URL
 
 BUILDAH_DEB_PACKAGES_PATH="${1:?Argument missing: BuildahDebPackagesPath}"
+PROXY="${2:-}"
 
 log_info() {
     echo "[BuildahPkg] $1"
@@ -20,6 +22,14 @@ log_info() {
 
 log_info "Starting download of buildah packages"
 log_info "Target path: $BUILDAH_DEB_PACKAGES_PATH"
+
+cleanup_proxy_config() {
+    if [ -n "$PROXY" ]; then
+        sudo rm -f /etc/apt/apt.conf.d/95k2s-proxy
+    fi
+}
+
+trap cleanup_proxy_config EXIT
 
 # ---------------------------------------------------------------------------
 # Prepare target directory
@@ -31,6 +41,12 @@ mkdir -p "$BUILDAH_DEB_PACKAGES_PATH"
 
 # APT sandbox config
 echo 'APT::Sandbox::User "root";' | sudo tee /etc/apt/apt.conf.d/10sandbox-for-k2s > /dev/null
+
+# Configure apt proxy if provided (ensures apt-get download uses the same proxy path)
+if [ -n "$PROXY" ]; then
+    log_info "Configuring apt proxy: $PROXY"
+    printf 'Acquire::http::Proxy "%s";\nAcquire::https::Proxy "%s";\n' "$PROXY" "$PROXY" | sudo tee /etc/apt/apt.conf.d/95k2s-proxy > /dev/null
+fi
 
 cd "$BUILDAH_DEB_PACKAGES_PATH"
 

--- a/cfg/nodeextension/debian12/scripts/download-k8s-packages.sh
+++ b/cfg/nodeextension/debian12/scripts/download-k8s-packages.sh
@@ -64,6 +64,12 @@ cleanup_and_create "$TARGET_PATH"
 # # APT sandbox config
 echo "APT::Sandbox::User \"root\";" | sudo tee /etc/apt/apt.conf.d/10sandbox-for-k2s > /dev/null
 
+# Configure apt proxy if provided (ensures apt-get update/download use the same proxy as curl)
+if [ -n "$PROXY" ]; then
+    log_info "Configuring apt proxy: $PROXY"
+    printf 'Acquire::http::Proxy "%s";\nAcquire::https::Proxy "%s";\n' "$PROXY" "$PROXY" | sudo tee /etc/apt/apt.conf.d/95k2s-proxy > /dev/null
+fi
+
 # Copy ZScaler certificate (if exists)
 if [ -f /tmp/ZScalerRootCA.crt ]; then
     log_info "Adding ZScaler certificate"
@@ -274,5 +280,10 @@ cd "$TARGET_PATH" && sudo find . -maxdepth 1 -type f \
 log_info "Download verification:"
 log_info "Total packages: $(ls "$TARGET_PATH"/*.deb 2>/dev/null | wc -l)"
 ls -lh "$TARGET_PATH"/*.deb 2>/dev/null || true
+
+# Remove temporary apt proxy config
+if [ -n "$PROXY" ]; then
+    sudo rm -f /etc/apt/apt.conf.d/95k2s-proxy
+fi
 
    

--- a/cfg/nodeextension/debian13/scripts/download-buildah-packages.sh
+++ b/cfg/nodeextension/debian13/scripts/download-buildah-packages.sh
@@ -16,8 +16,10 @@
 # Arguments:
 #   $1 - Target path on the remote machine to store downloaded .deb packages
 #        (e.g. /home/sk/apt-offline-k2s/buildah)
+#   $2 - Optional HTTP/HTTPS proxy URL
 
 BUILDAH_DEB_PACKAGES_PATH="${1:?Argument missing: BuildahDebPackagesPath}"
+PROXY="${2:-}"
 
 log_info() {
     echo "[BuildahPkg] $1"
@@ -25,6 +27,14 @@ log_info() {
 
 log_info "Starting download of buildah packages"
 log_info "Target path: $BUILDAH_DEB_PACKAGES_PATH"
+
+cleanup_proxy_config() {
+    if [ -n "$PROXY" ]; then
+        sudo rm -f /etc/apt/apt.conf.d/95k2s-proxy
+    fi
+}
+
+trap cleanup_proxy_config EXIT
 
 # ---------------------------------------------------------------------------
 # Prepare target directory
@@ -36,6 +46,12 @@ mkdir -p "$BUILDAH_DEB_PACKAGES_PATH"
 
 # APT sandbox config
 echo 'APT::Sandbox::User "root";' | sudo tee /etc/apt/apt.conf.d/10sandbox-for-k2s > /dev/null
+
+# Configure apt proxy if provided (ensures apt-get download uses the same proxy path)
+if [ -n "$PROXY" ]; then
+    log_info "Configuring apt proxy: $PROXY"
+    printf 'Acquire::http::Proxy "%s";\nAcquire::https::Proxy "%s";\n' "$PROXY" "$PROXY" | sudo tee /etc/apt/apt.conf.d/95k2s-proxy > /dev/null
+fi
 
 cd "$BUILDAH_DEB_PACKAGES_PATH"
 

--- a/cfg/nodeextension/debian13/scripts/download-k8s-packages.sh
+++ b/cfg/nodeextension/debian13/scripts/download-k8s-packages.sh
@@ -325,4 +325,9 @@ log_info "Download verification:"
 log_info "Total packages: $(ls "$TARGET_PATH"/*.deb 2>/dev/null | wc -l)"
 ls -lh "$TARGET_PATH"/*.deb 2>/dev/null || true
 
+# Remove temporary apt proxy config
+if [ -n "$PROXY" ]; then
+    sudo rm -f /etc/apt/apt.conf.d/90k2s-proxy
+fi
+
    

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -559,6 +559,7 @@ Function Get-BuildahDebPackagesFromInternet {
         [string]$UserPwd = '',
         [ValidateScript({ Get-IsValidIPv4Address($_) })]
         [string]$IpAddress = $(throw 'Argument missing: IpAddress'),
+        [string]$Proxy = '',
         [string]$TargetPath = $(throw 'Argument missing: TargetPath'),
         [string]$InstalledDistribution = 'debian12'
     )
@@ -571,7 +572,7 @@ Function Get-BuildahDebPackagesFromInternet {
                         -UserName $UserName `
                         -IpAddress $IpAddress `
                         -UserPwd $UserPwd `
-                        -Arguments @($TargetPath) `
+                        -Arguments @($TargetPath, $Proxy) `
                         -CleanupAfterExecution `
                         -Retries 2
 

--- a/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
@@ -209,6 +209,7 @@ try {
         -UserName              $sshUser `
         -UserPwd               $sshPwd `
         -IpAddress             $guestIp `
+        -Proxy                 $Proxy `
         -TargetPath            $remoteBuildahPkgDir `
         -InstalledDistribution $distributionKey
 


### PR DESCRIPTION
Summary
This change fixes package download failures in proxied environments by ensuring APT operations (apt-get update/download/install) use the provided proxy during node package creation, then cleaning up proxy settings afterward.

Node package creation passed proxy values into scripts, but some download paths still relied on APT without explicit proxy configuration. In those cases, APT attempted direct internet access and failed (timeouts / mirror fetch errors), leading to missing packages (for example gpg).

curl paths used proxy flags, but APT commands require proxy configuration via apt.conf.d to be consistently applied.