### PR TITLE
Increasing retry wait timeout for core_test.go test faiulre

### DIFF
--- a/k2s/test/framework/k8s/k8s.go
+++ b/k2s/test/framework/k8s/k8s.go
@@ -597,11 +597,11 @@ func (c *Cluster) ExpectInternetToBeReachableFromPodOfDeployment(deploymentName 
 
 	Expect(err).ShouldNot(HaveOccurred())
 
-	command := []string{"curl", "-i", "-m", "10", "--retry", "3", "--insecure", "www.msftconnecttest.com/connecttest.txt"}
+	command := []string{"curl", "-i", "-m", "30", "--retry", "3", "--insecure", "www.msftconnecttest.com/connecttest.txt"}
 	if proxy != "" {
 		GinkgoWriter.Println("Using proxy for curl")
 
-		command = []string{"curl", "-i", "-m", "10", "--retry", "3", "--insecure", "-x", proxy, "www.msftconnecttest.com/connecttest.txt"}
+		command = []string{"curl", "-i", "-m", "30", "--retry", "3", "--insecure", "-x", proxy, "www.msftconnecttest.com/connecttest.txt"}
 	}
 
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
Increasing retry wait timeout for core_test.go failure in add node offline 