### PR TITLE
Increasing export and import test timeout period , e2e test failure

### DIFF
--- a/k2s/test/e2e/addons/logging/exportimport/logging_export_import_test.go
+++ b/k2s/test/e2e/addons/logging/exportimport/logging_export_import_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const exportImportTestTimeout = time.Minute * 30
+const exportImportTestTimeout = time.Minute * 60
 
 var (
 	suite                 *framework.K2sTestSuite


### PR DESCRIPTION
The Tests failed with an below timeout error while import and export a large file 
[2026-04-23|01:26:07.842348]   [FAILED] Timed out after 1800.002s. 
Increased the test timeout period.