### PR TITLE
Increasing cluster test step timout period , add node online test case scenario

### DIFF
--- a/k2s/test/e2e/cluster/node/node_test.go
+++ b/k2s/test/e2e/cluster/node/node_test.go
@@ -54,7 +54,11 @@ func TestClusterCore(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(ctx context.Context) {
-	suite = framework.Setup(ctx, framework.ClusterTestStepPollInterval(time.Millisecond*200))
+	suite = framework.Setup(
+		ctx,
+		framework.ClusterTestStepTimeout(time.Minute*10),
+		framework.ClusterTestStepPollInterval(time.Millisecond*200),
+	)
 	k2s = dsl.NewK2s(suite)
 
 	suite.SetupInfo().LoadClusterConfig()


### PR DESCRIPTION
Increasing cluster test step timout period , add node online test case scenario , to solve the below test case error 
Error : client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadli