### PR TITLE
#1218 Logging addon reliability fixes

### DIFF
--- a/addons/logging/Disable.ps1
+++ b/addons/logging/Disable.ps1
@@ -86,6 +86,7 @@ if ($omitOpensearch) {
     (Invoke-Kubectl -Params 'delete', 'pod', '-l', 'app.kubernetes.io/name=fluent-bit-win', '-n', 'logging', '--grace-period=0', '--force', '--ignore-not-found').Output | Write-Log
 
     (Invoke-Kubectl -Params 'delete', 'namespace', 'logging', '--ignore-not-found').Output | Write-Log
+    (Invoke-Kubectl -Params 'delete', 'pv', 'opensearch-cluster-master-pv', '--ignore-not-found', '--wait=false').Output | Write-Log
 
     (Invoke-CmdOnControlPlaneViaSSHKey -Timeout 2 -CmdToExecute 'sudo rm -rf /logging').Output | Write-Log
 }
@@ -110,6 +111,7 @@ else {
     }
 
     (Invoke-Kubectl -Params 'delete', 'namespace', 'logging', '--grace-period=0').Output | Write-Log
+    (Invoke-Kubectl -Params 'delete', 'pv', 'opensearch-cluster-master-pv', '--ignore-not-found', '--wait=false').Output | Write-Log
 
     (Invoke-CmdOnControlPlaneViaSSHKey -Timeout 2 -CmdToExecute 'sudo rm -rf /logging').Output | Write-Log
     (Invoke-CmdOnControlPlaneViaSSHKey -Timeout 2 -CmdToExecute 'sudo rm -f /etc/sysctl.d/99-opensearch.conf').Output | Write-Log

--- a/addons/logging/Disable.ps1
+++ b/addons/logging/Disable.ps1
@@ -112,6 +112,7 @@ else {
     (Invoke-Kubectl -Params 'delete', 'namespace', 'logging', '--grace-period=0').Output | Write-Log
 
     (Invoke-CmdOnControlPlaneViaSSHKey -Timeout 2 -CmdToExecute 'sudo rm -rf /logging').Output | Write-Log
+    (Invoke-CmdOnControlPlaneViaSSHKey -Timeout 2 -CmdToExecute 'sudo rm -f /etc/sysctl.d/99-opensearch.conf').Output | Write-Log
 }
 
 Remove-AddonFromSetupJson -Addon ([pscustomobject] @{Name = 'logging' })

--- a/addons/logging/Enable.ps1
+++ b/addons/logging/Enable.ps1
@@ -85,6 +85,9 @@ if ($Ingress -ne 'none') {
 
 (Invoke-CmdOnControlPlaneViaSSHKey -Timeout 2 -CmdToExecute 'sudo mkdir -m 777 -p /logging').Output | Write-Log
 
+# OpenSearch requires vm.max_map_count >= 262144; set it persistently so it survives reboots
+(Invoke-CmdOnControlPlaneViaSSHKey -Timeout 2 -CmdToExecute 'echo "vm.max_map_count=262144" | sudo tee /etc/sysctl.d/99-opensearch.conf && sudo sysctl -w vm.max_map_count=262144').Output | Write-Log
+
 $manifestsPath = "$PSScriptRoot\manifests\logging"
 
 function Stop-WithError ([string]$Message) {
@@ -139,11 +142,16 @@ else {
     # fluent-bit linux
 
     (Invoke-Kubectl -Params 'apply', '-f', "$manifestsPath\namespace.yaml").Output | Write-Log
-    (Invoke-Kubectl -Params 'create', '-k', "$manifestsPath\").Output | Write-Log
+
+    $createResult = Invoke-Kubectl -Params 'create', '-k', "$manifestsPath\"
+    $createResult.Output | Write-Log
+    if (!$createResult.Success) { Stop-WithError "Failed to create logging resources: $($createResult.Output)" }
 
     # fluent-bit windows
     if ($setupInfo.LinuxOnly -eq $false) {
-        (Invoke-Kubectl -Params 'create', '-k', "$manifestsPath\fluentbit\windows").Output | Write-Log
+        $createWinResult = Invoke-Kubectl -Params 'create', '-k', "$manifestsPath\fluentbit\windows"
+        $createWinResult.Output | Write-Log
+        if (!$createWinResult.Success) { Stop-WithError "Failed to create logging Windows resources: $($createWinResult.Output)" }
     }
 
     Write-Log 'Waiting for pods being ready...' -Console
@@ -151,7 +159,12 @@ else {
     # Wait for opensearch (StatefulSet) first — dashboards depends on opensearch being available at port 9200
     $kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'statefulsets', '-n', 'logging', '--timeout=600s')
     Write-Log $kubectlCmd.Output
-    if (!$kubectlCmd.Success) { Stop-WithError 'Opensearch could not be deployed successfully!' }
+    if (!$kubectlCmd.Success) {
+        Write-Log '[Logging] Rollout status timed out - gathering diagnostics' -Console
+        (Invoke-Kubectl -Params 'describe', 'pod', '-n', 'logging', '-l', 'app.kubernetes.io/name=opensearch').Output | Write-Log
+        (Invoke-Kubectl -Params 'get', 'events', '-n', 'logging', '--sort-by=.lastTimestamp').Output | Write-Log
+        Stop-WithError 'Opensearch could not be deployed successfully!'
+    }
 
     $kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'deployments', '-n', 'logging', '--timeout=600s')
     Write-Log $kubectlCmd.Output

--- a/addons/logging/manifests/logging/opensearch/statefulset.yaml
+++ b/addons/logging/manifests/logging/opensearch/statefulset.yaml
@@ -73,24 +73,6 @@ spec:
           name: config-emptydir
       enableServiceLinks: true
       initContainers:
-        - name: fsgroup-volume
-          image: "docker.io/library/busybox:1.37.0"
-          imagePullPolicy: "IfNotPresent"
-          command: ["sh", "-c"]
-          args:
-            - "chown -R 1000:1000 /usr/share/opensearch/data"
-          securityContext:
-            runAsUser: 0
-          resources:
-            limits:
-              cpu: 25m
-              memory: 128Mi
-            requests:
-              cpu: 25m
-              memory: 128Mi
-          volumeMounts:
-            - name: "opensearch-cluster-master"
-              mountPath: /usr/share/opensearch/data
         - name: configfile
           image: "docker.io/opensearchproject/opensearch:3.6.0"
           imagePullPolicy: "IfNotPresent"
@@ -147,7 +129,7 @@ spec:
           resources:
             requests:
               cpu: 500m
-              memory: 1Gi
+              memory: 768Mi
           env:
             - name: node.name
               valueFrom:


### PR DESCRIPTION

#1218 

Changes:

- Set vm.max_map_count=262144 during logging enable and persist it on the control-plane VM.
- Remove the redundant fsgroup-volume init container (busybox:1.37.0) and rely on pod fsGroup ownership handling.
- Add cleanup of the OpenSearch sysctl file during logging disable.
- Fail fast if kubectl create -k fails (instead of continuing silently).
- Add rollout timeout diagnostics (describe pod + events) before failing.
- Reduce OpenSearch memory request from 1Gi to 768Mi to improve scheduling when security/linkerd components are already running.
- Disable.ps1 force deletes PV 