### PR TITLE
#1863 Fixes for upgrade delta

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -1471,10 +1471,11 @@ function Install-HelmAndYqOnKubeMaster
     $installResult = Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "sudo $remoteScriptPath" -RemoteUser "$UserName@$IpAddress" -RemoteUserPwd $UserPwd
     $installResult.Output | Write-Log
     if (-not $installResult.Success) {
-        throw "[InstallHelmYq] install-helm-yq.sh failed on $IpAddress. Check network connectivity and proxy settings."
+        Write-Log "[InstallHelmYq] WARNING: install-helm-yq.sh failed on $IpAddress. Helm/yq may not be available. Check network connectivity and proxy settings." -Console
     }
-    
-    Write-Log "install-helm-yq.sh copied and executed successfully on $IpAddress"
+    else {
+        Write-Log "install-helm-yq.sh copied and executed successfully on $IpAddress"
+    }
 }
 
 function Set-HypervDynamicMemory

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -1154,7 +1154,7 @@ failCgroupV1: false
     }
     $prePullResult.Output | Write-Log
     if (-not $prePullResult.Success) {
-        Write-Log '[KubeInit] WARNING: Pre-pulling images failed, kubeadm init will attempt to pull them' -Console
+        throw '[KubeInit] Pre-pulling Kubernetes images failed after retries. Check proxy settings and network connectivity to container registry (registry.k8s.io).'
     }
 
     &$executeRemoteCommand 'mkdir -p ~/tmp/kubeadm-init'
@@ -1468,7 +1468,11 @@ function Install-HelmAndYqOnKubeMaster
     }
     (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "sudo chmod +x $remoteScriptPath" -RemoteUser "$UserName@$IpAddress" -RemoteUserPwd $UserPwd).Output | Write-Log
     (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "sudo sed -i 's/\r$//' $remoteScriptPath" -RemoteUser "$UserName@$IpAddress" -RemoteUserPwd $UserPwd).Output | Write-Log
-    (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "sudo $remoteScriptPath" -RemoteUser "$UserName@$IpAddress" -RemoteUserPwd $UserPwd).Output | Write-Log
+    $installResult = Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "sudo $remoteScriptPath" -RemoteUser "$UserName@$IpAddress" -RemoteUserPwd $UserPwd
+    $installResult.Output | Write-Log
+    if (-not $installResult.Success) {
+        throw "[InstallHelmYq] install-helm-yq.sh failed on $IpAddress. Check network connectivity and proxy settings."
+    }
     
     Write-Log "install-helm-yq.sh copied and executed successfully on $IpAddress"
 }

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/scripts/install-helm-yq.sh
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/scripts/install-helm-yq.sh
@@ -30,7 +30,7 @@ if ! command -v yq &> /dev/null; then
     if [[ "$ARCH" == "x86_64" ]]; then
         ARCH="amd64"
     fi
-    sudo curl -L $CURL_PROXY_OPT -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}" --silent
+    sudo curl -fL $CURL_PROXY_OPT -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}" --silent
     sudo chmod +x /usr/local/bin/yq
     yq --version
 else
@@ -45,7 +45,7 @@ if ! command -v helm &> /dev/null; then
     if [[ "$ARCH" == "x86_64" ]]; then
         ARCH="amd64"
     fi
-    curl -L $CURL_PROXY_OPT -o "helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" --silent
+    curl -fL $CURL_PROXY_OPT -o "helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" --silent
     tar -xzf "helm-${HELM_VERSION}-linux-${ARCH}.tar.gz"
     sudo mv "linux-${ARCH}/helm" /usr/local/bin/helm
     sudo chmod +x /usr/local/bin/helm


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #1863
1. kubeadm config images pull — now fatal on failure

File: common-setup.module.psm1 (line ~1156)

 - Before: Logged a warning and continued to kubeadm init with missing images
 - After: Throws after all 4 attempts are exhausted, aborting the upgrade early instead of producing a broken cluster

2. install-helm-yq.sh — curl now detects HTTP errors

File: install-helm-yq.sh (lines 33, 48)

 - Before: curl -L silently wrote error pages to disk on 502/404
 - After: curl -fL returns non-zero on HTTP errors, caught by set -e

3. Install-HelmAndYqOnKubeMaster — checks script exit code

File: common-setup.module.psm1 (line ~1471)

 - Before: Always logged "executed successfully" regardless of exit code
 - After: Checks result and logs a visible warning on failure (non-fatal, since helm/yq aren't required for the cluster)


### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->