### PR TITLE
Monitoring addon nightly fix

### DIFF
--- a/addons/monitoring/Update.ps1
+++ b/addons/monitoring/Update.ps1
@@ -52,7 +52,7 @@ if ($EnancedSecurityEnabled) {
 		Write-Log "windows-exporter DaemonSet not found in kube-system, skipping linkerd injection patch"
 	}
 
-	$maxAttempts = 30
+	$maxAttempts = 60
 	$attempt = 0
 	do {
 		$attempt++
@@ -102,7 +102,7 @@ if ($EnancedSecurityEnabled) {
 		Write-Log "windows-exporter DaemonSet not found in kube-system, skipping linkerd removal patch"
 	}
 
-	$maxAttempts = 30
+	$maxAttempts = 60
 	$attempt = 0
 	do {
 		$attempt++

--- a/k2s/test/e2e/addons/monitoring/securityenhanced/monitoring_security_test.go
+++ b/k2s/test/e2e/addons/monitoring/securityenhanced/monitoring_security_test.go
@@ -78,7 +78,7 @@ var _ = Describe("'monitoring and security enhanced' addons", Ordered, func() {
 
 		It("is in enabled state and pods are in running state", func(ctx context.Context) {
 			GinkgoWriter.Println(">>> TEST: Enabling monitoring addon")
-			suite.K2sCli().MustExec(ctx, "addons", "enable", "monitoring", "-o")
+			suite.K2sCli().MustExec(ctx, "addons", "enable", "monitoring", "--ingress", "nginx", "-o")
 
 			k2s.VerifyAddonIsEnabled("monitoring")
 
@@ -115,9 +115,16 @@ var _ = Describe("'monitoring and security enhanced' addons", Ordered, func() {
 
 
 	Describe("Monitoring addon activated first then security addon", func() {
+		It("activates the ingress addon with nginx", func(ctx context.Context) {
+			GinkgoWriter.Println(">>> TEST: Enabling ingress addon with nginx")
+			suite.K2sCli().MustExec(ctx, "addons", "enable", "ingress", "nginx", "-o")
+			suite.Cluster().ExpectDeploymentToBeAvailable("ingress-nginx-controller", "ingress-nginx")
+			GinkgoWriter.Println(">>> TEST: Ingress nginx addon enabled")
+		})
+
 		It("activates the monitoring addon", func(ctx context.Context) {
 			GinkgoWriter.Println(">>> TEST: Enabling monitoring addon first")
-			suite.K2sCli().MustExec(ctx, "addons", "enable", "monitoring", "-o")
+			suite.K2sCli().MustExec(ctx, "addons", "enable", "monitoring", "--ingress", "nginx", "-o")
 			GinkgoWriter.Println(">>> TEST: Monitoring addon enabled")
 		})
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes token issue in monitoring nightly tests.

### Motivation

Postgres pod hangs waiting for linkerd-proxy before linkerd is installed.

### Modifications

Made Postgres start safely with the Linkerd sidecar & shut down cleanly.

### Verification

Ran securityenhanced e2e suite locally — all specs passed.

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->