### PR TITLE
Fixing K2S installation failure due to a wrongly interpreted path string generated for containerd

### DIFF
--- a/lib/modules/k2s/k2s.node.module/windowsnode/downloader/artifacts/containerd/containerd.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/windowsnode/downloader/artifacts/containerd/containerd.module.psm1
@@ -146,8 +146,9 @@ function Set-RootPathForImagesInConfig($tomlPath) {
         Write-Log 'StorageLocalDrive is '
         Write-Log $storageLocalDrive
         $storageLocalDriveWithFolderName = $storageLocalDrive + $storageLocalFolder        
-        Write-Log "StorageLocalDriveWithFolderName is'$storageLocalDriveWithFolderName'"
-        (Get-Content -path $template -Raw) -replace '%BEST-DRIVE%', $storageLocalDriveWithFolderName | Set-Content -Path $tomlPath
+        Write-Log "StorageLocalDriveWithFolderName is '$storageLocalDriveWithFolderName'"
+        $formattedPath = $storageLocalDriveWithFolderName.Replace('\', '\\')
+        (Get-Content -path $template -Raw) -replace '%BEST-DRIVE%', $formattedPath | Set-Content -Path $tomlPath
     }    
 }
 


### PR DESCRIPTION
K2S installation fails due to a wrongly interpreted/formated path string generated for containerd

Root cause for the failure seems to be that the containerd config.toml contains invalid entries - \\ is replaced by just \

Added a replace function to replace \ to \\ , to support toml format