### PR TITLE
1863 add linux node sporadic test failures fixes

### DIFF
--- a/cfg/nodeextension/debian12/scripts/download-k8s-packages.sh
+++ b/cfg/nodeextension/debian12/scripts/download-k8s-packages.sh
@@ -262,6 +262,9 @@ set_kubernetes_apt_repository "$K8S_VERSION_REPO" "$PROXY"
 log_info "=== Downloading CRI-O ==="
 download_packages 'cri-o'
 
+log_info "=== Downloading cri-tools (crictl) ==="
+download_packages 'cri-tools'
+
 log_info "=== Downloading Kubernetes Tools ==="
 SHORT_K8S_VERSION="${K8S_VERSION#v}-1.1"
 log_info "Target Kubernetes version: $SHORT_K8S_VERSION"

--- a/cfg/nodeextension/debian13/scripts/download-k8s-packages.sh
+++ b/cfg/nodeextension/debian13/scripts/download-k8s-packages.sh
@@ -306,6 +306,9 @@ set_kubernetes_apt_repository "$K8S_VERSION_REPO" "$PROXY"
 log_info "=== Downloading CRI-O ==="
 download_packages 'cri-o'
 
+log_info "=== Downloading cri-tools (crictl) ==="
+download_packages 'cri-tools'
+
 log_info "=== Downloading Kubernetes Tools ==="
 SHORT_K8S_VERSION="${K8S_VERSION#v}-1.1"
 log_info "Target Kubernetes version: $SHORT_K8S_VERSION"

--- a/k2s/test/e2e/cluster/node/node_test.go
+++ b/k2s/test/e2e/cluster/node/node_test.go
@@ -74,6 +74,16 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	GinkgoWriter.Println("Found Linux nodes:", linuxNodes, len(linuxNodes))
 	GinkgoWriter.Println("Found Windows nodes:", windowsNodes, len(windowsNodes))
 
+	// Wait for all nodes to be Ready before deploying workloads
+	GinkgoWriter.Println("Waiting for all nodes to be in Ready state...")
+	for _, node := range linuxNodes {
+		suite.Cluster().WaitForNodeToBeReady(node, ctx)
+	}
+	for _, node := range windowsNodes {
+		suite.Cluster().WaitForNodeToBeReady(node, ctx)
+	}
+	GinkgoWriter.Println("All nodes are Ready")
+
 	linuxImage := "shsk2s.azurecr.io/example.albums-golang-linux:v1.0.0"
 	windowsImage := "shsk2s.azurecr.io/example.albums-golang-win:v1.0.0"
 

--- a/k2s/test/e2e/cluster/nodehyperv/node_hyperv_linuxvm_test.go
+++ b/k2s/test/e2e/cluster/nodehyperv/node_hyperv_linuxvm_test.go
@@ -38,7 +38,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	suite = framework.Setup(ctx,
 		framework.SystemMustBeRunning,
 		framework.ClusterTestStepPollInterval(500*time.Millisecond),
-		framework.ClusterTestStepTimeout(10*time.Minute))
+		framework.ClusterTestStepTimeout(20*time.Minute))
 	k2s = dsl.NewK2s(suite)
 
 	DeferCleanup(suite.TearDown)

--- a/k2s/test/e2e/cluster/systemdump/dump_systemrunning_test.go
+++ b/k2s/test/e2e/cluster/systemdump/dump_systemrunning_test.go
@@ -29,6 +29,7 @@ func TestSystemDump(t *testing.T) {
 var _ = BeforeSuite(func(ctx context.Context) {
 	suite = framework.Setup(ctx, framework.SystemMustBeRunning,
 		framework.ClusterTestStepPollInterval(200*time.Millisecond),
+		framework.ClusterTestStepTimeout(15*time.Minute),
 	)
 })
 

--- a/k2s/test/framework/k8s/k8s.go
+++ b/k2s/test/framework/k8s/k8s.go
@@ -747,6 +747,29 @@ func (c *Cluster) ExpectDNSToBeResolvableFromHost(ctx context.Context, serviceNa
 	}, c.testStepTimeout, c.testStepPollInterval, ctx).Should(Succeed(), "DNS resolution of <"+fqdn+"> should succeed")
 }
 
+// WaitForNodeToBeReady polls until the node transitions to Ready state.
+// This is useful in BeforeSuite to ensure nodes are ready before deploying workloads.
+func (c *Cluster) WaitForNodeToBeReady(name string, ctx context.Context) {
+	GinkgoWriter.Println("Waiting for node <", name, "> to become Ready...")
+
+	Eventually(func() bool {
+		var node corev1.Node
+		err := c.Client().Resources().Get(ctx, name, "", &node)
+		if err != nil {
+			GinkgoWriter.Println("Error getting node <", name, ">:", err)
+			return false
+		}
+
+		ready := isNodeReady(node)
+		if !ready {
+			GinkgoWriter.Println("Node <", name, "> is not Ready yet, waiting...")
+		}
+		return ready
+	}, c.testStepTimeout, c.testStepPollInterval, ctx).Should(BeTrue(), "Node <%s> should become Ready", name)
+
+	GinkgoWriter.Println("Node <", name, "> is Ready")
+}
+
 func (c *Cluster) ExpectNodeToBeReady(name string, ctx context.Context) {
 	var node corev1.Node
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
@@ -464,7 +464,9 @@ function Invoke-CmdOnControlPlaneViaUserAndPwd(
     [uint16]$Retrycount = 1
     do {
         try {
-            $output = &"$plinkExe" -ssh -4 -legacy-stdio-prompts $RemoteUser -pw $RemoteUserPwd -no-antispoof $CmdToExecute 2>&1 | ForEach-Object { Write-Log $_ -Console -Raw }
+            $outputLines = @(&"$plinkExe" -ssh -4 -legacy-stdio-prompts $RemoteUser -pw $RemoteUserPwd -no-antispoof $CmdToExecute 2>&1)
+            $outputLines | ForEach-Object { Write-Log $_ -Console -Raw }
+            $output = $outputLines
             $success = ($LASTEXITCODE -eq 0)
             if (!$success -and !$IgnoreErrors) { throw "Error occurred while executing command '$CmdToExecute' (exit code: '$LASTEXITCODE')" }
             $Stoploop = $true

--- a/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
@@ -464,7 +464,8 @@ function Invoke-CmdOnControlPlaneViaUserAndPwd(
     [uint16]$Retrycount = 1
     do {
         try {
-            $outputLines = @(&"$plinkExe" -ssh -4 -legacy-stdio-prompts $RemoteUser -pw $RemoteUserPwd -no-antispoof $CmdToExecute 2>&1)
+            # Capture plink output and convert ErrorRecords (stderr) to strings to prevent PowerShell error handling
+            $outputLines = @(&"$plinkExe" -ssh -4 -legacy-stdio-prompts $RemoteUser -pw $RemoteUserPwd -no-antispoof $CmdToExecute 2>&1 | ForEach-Object { "$_" })
             $outputLines | ForEach-Object { Write-Log $_ -Console -Raw }
             $output = $outputLines
             $success = ($LASTEXITCODE -eq 0)

--- a/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
@@ -464,10 +464,7 @@ function Invoke-CmdOnControlPlaneViaUserAndPwd(
     [uint16]$Retrycount = 1
     do {
         try {
-            # Capture plink output and convert ErrorRecords (stderr) to strings to prevent PowerShell error handling
-            $outputLines = @(&"$plinkExe" -ssh -4 -legacy-stdio-prompts $RemoteUser -pw $RemoteUserPwd -no-antispoof $CmdToExecute 2>&1 | ForEach-Object { "$_" })
-            $outputLines | ForEach-Object { Write-Log $_ -Console -Raw }
-            $output = $outputLines
+            $output = &"$plinkExe" -ssh -4 -legacy-stdio-prompts $RemoteUser -pw $RemoteUserPwd -no-antispoof $CmdToExecute 2>&1 | ForEach-Object { Write-Log $_ -Console -Raw }
             $success = ($LASTEXITCODE -eq 0)
             if (!$success -and !$IgnoreErrors) { throw "Error occurred while executing command '$CmdToExecute' (exit code: '$LASTEXITCODE')" }
             $Stoploop = $true


### PR DESCRIPTION
Add linux node workflows were failing with the error ConvertFrom-Json: Invalid JSON primitive 

Reason : the crictl tools packages were not installed , with the new cri-o package the crictl tools package is seperated . downloading the crictl tool package seperately. 

Test timeouts increased