### PR TITLE
#2014 Retain addons in enabled state after system upgrade

### DIFF
--- a/addons/addons.module.psm1
+++ b/addons/addons.module.psm1
@@ -2289,7 +2289,7 @@ function Assert-IngressTlsCertificate {
     return $certExists
 }
 
-Export-ModuleMember -Function Get-EnabledAddons, Add-AddonToSetupJson, Remove-AddonFromSetupJson,
+Export-ModuleMember -Function Enable-AddonFromConfig, Get-EnabledAddons, Add-AddonToSetupJson, Remove-AddonFromSetupJson,
 Install-DebianPackages, Get-DebianPackageAvailableOffline, Test-IsAddonEnabled, Invoke-AddonsHooks, Copy-ScriptsToHooksDir,
 Remove-ScriptsFromHooksDir, Get-AddonConfig, Backup-Addons, Restore-Addons, Get-AddonStatus, Find-AddonManifests,
 Get-ErrCodeAddonAlreadyDisabled, Get-ErrCodeAddonAlreadyEnabled, Get-ErrCodeAddonEnableFailed, Get-ErrCodeAddonNotFound, Get-ErrCodeInvalidParameter,

--- a/k2s/test/e2e/cluster/upgrade/upgrade_validation_test.go
+++ b/k2s/test/e2e/cluster/upgrade/upgrade_validation_test.go
@@ -190,6 +190,22 @@ var _ = Describe("Upgrade Validation", func() {
 			}
 		})
 	})
+
+	Describe("Addon Preservation", Label("upgrade-addon-validation"), func() {
+		It("metrics addon is re-enabled and reported as enabled after upgrade", func(ctx SpecContext) {
+			if !k2s.IsAddonEnabled("metrics") {
+				Skip("metrics addon was not enabled before upgrade, skipping re-enable check")
+			}
+
+			// Verify setup.json reflects the addon as enabled
+			k2s.VerifyAddonIsEnabled("metrics")
+
+			// Verify the CLI also reports the addon as enabled
+			output := suite.K2sCli().MustExec(ctx, "addons", "status", "metrics")
+			Expect(output).To(MatchRegexp(`Addon .+metrics.+ is .+enabled.+`),
+				"metrics addon should be reported as enabled after upgrade")
+		})
+	})
 })
 
 func isPodReady(pod corev1.Pod) bool {

--- a/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.psm1
+++ b/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.psm1
@@ -5,8 +5,9 @@
 $infraModule = "$PSScriptRoot/../../k2s.infra.module/k2s.infra.module.psm1"
 $imageBackupModule = "$PSScriptRoot/../image/ImageBackup.module.psm1"
 $pvBackupModule = "$PSScriptRoot/BackupPersistentVolumes.psm1"
+$addonsModule = "$PSScriptRoot/../../../../../addons/addons.module.psm1"
 
-Import-Module $infraModule, $imageBackupModule, $pvBackupModule
+Import-Module $infraModule, $imageBackupModule, $pvBackupModule, $addonsModule
 
 $processTools = @'
 

--- a/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.psm1
+++ b/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.psm1
@@ -5,9 +5,8 @@
 $infraModule = "$PSScriptRoot/../../k2s.infra.module/k2s.infra.module.psm1"
 $imageBackupModule = "$PSScriptRoot/../image/ImageBackup.module.psm1"
 $pvBackupModule = "$PSScriptRoot/BackupPersistentVolumes.psm1"
-$addonsModule = "$PSScriptRoot/../../../../../addons/addons.module.psm1"
 
-Import-Module $infraModule, $imageBackupModule, $pvBackupModule, $addonsModule
+Import-Module $infraModule, $imageBackupModule, $pvBackupModule
 
 $processTools = @'
 

--- a/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.unit.tests.ps1
+++ b/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.unit.tests.ps1
@@ -321,6 +321,7 @@ Describe "PerformClusterUpgrade" {
 		Mock -ModuleName $moduleName Out-File
 		Mock -ModuleName $moduleName Wait-ForAPIServerInGivenKubePath
 		Mock -ModuleName $moduleName Get-KubeBinPathGivenKubePath -MockWith { return "C:\KubeBinPath" }
+		Mock -ModuleName $moduleName Enable-AddonFromConfig
 	}
 
 	It "should perform cluster upgrade with execute hooks successfully" {
@@ -384,6 +385,69 @@ Describe "PerformClusterUpgrade" {
 			$logFilePathBeforeUninstall = [ref]"C:\Backup\logfile.log"
 	
 			{ PerformClusterUpgrade -ShowProgress -DeleteFiles -ShowLogs -K2sPathToInstallFrom "C:\K2sPath" -Config "config.yaml" -Proxy "http://proxy" -BackupDir "C:\Backup" -AdditionalHooksDir "C:\Hooks" -memoryVM $memoryVM -coresVM $coresVM -storageVM $storageVM -enabledAddonsList $enabledAddonsList -hooksBackupPath $hooksBackupPath -logFilePathBeforeUninstall $logFilePathBeforeUninstall } | Should -Throw "Uninstall failed"
+		}
+	}
+
+	It 'calls Enable-AddonFromConfig for each addon in enabledAddonsList' {
+		InModuleScope $moduleName {
+			$memoryVM = @{ Startup = '4GB'; DynamicMemoryEnabled = $false }
+			$coresVM = [ref]'2'
+			$storageVM = [ref]'100GB'
+			$enabledAddonsList = [System.Collections.ArrayList]@(
+				[pscustomobject]@{ Name = 'dashboard' },
+				[pscustomobject]@{ Name = 'metrics' }
+			)
+			$hooksBackupPath = [ref]'C:\Backup\Hooks'
+			$logFilePathBeforeUninstall = [ref]'C:\Backup\logfile.log'
+
+			Mock Invoke-ClusterUninstall
+			Mock Enable-AddonFromConfig
+
+			PerformClusterUpgrade -ShowProgress -DeleteFiles -ShowLogs -K2sPathToInstallFrom 'C:\K2sPath' -Config 'config.yaml' -Proxy 'http://proxy' -BackupDir 'C:\Backup' -AdditionalHooksDir 'C:\Hooks' -memoryVM $memoryVM -coresVM $coresVM -storageVM $storageVM -enabledAddonsList $enabledAddonsList -hooksBackupPath $hooksBackupPath -logFilePathBeforeUninstall $logFilePathBeforeUninstall
+
+			Should -Invoke Enable-AddonFromConfig -Times 1 -Scope It -ParameterFilter { $Config.Name -eq 'dashboard' }
+			Should -Invoke Enable-AddonFromConfig -Times 1 -Scope It -ParameterFilter { $Config.Name -eq 'metrics' }
+			Should -Invoke Enable-AddonFromConfig -Times 2 -Scope It
+		}
+	}
+
+	It 'calls Enable-AddonFromConfig with Implementation set to first implementation when addon has implementations' {
+		InModuleScope $moduleName {
+			$memoryVM = @{ Startup = '4GB'; DynamicMemoryEnabled = $false }
+			$coresVM = [ref]'2'
+			$storageVM = [ref]'100GB'
+			$enabledAddonsList = [System.Collections.ArrayList]@(
+				[pscustomobject]@{ Name = 'ingress'; Implementations = @('traefik') }
+			)
+			$hooksBackupPath = [ref]'C:\Backup\Hooks'
+			$logFilePathBeforeUninstall = [ref]'C:\Backup\logfile.log'
+
+			Mock Invoke-ClusterUninstall
+			Mock Enable-AddonFromConfig
+
+			PerformClusterUpgrade -ShowProgress -DeleteFiles -ShowLogs -K2sPathToInstallFrom 'C:\K2sPath' -Config 'config.yaml' -Proxy 'http://proxy' -BackupDir 'C:\Backup' -AdditionalHooksDir 'C:\Hooks' -memoryVM $memoryVM -coresVM $coresVM -storageVM $storageVM -enabledAddonsList $enabledAddonsList -hooksBackupPath $hooksBackupPath -logFilePathBeforeUninstall $logFilePathBeforeUninstall
+
+			Should -Invoke Enable-AddonFromConfig -Times 1 -Scope It -ParameterFilter { $Config.Name -eq 'ingress' -and $Config.Implementation -eq 'traefik' }
+		}
+	}
+
+	It 'logs warning but does not throw when Enable-AddonFromConfig fails for an addon' {
+		InModuleScope $moduleName {
+			$memoryVM = @{ Startup = '4GB'; DynamicMemoryEnabled = $false }
+			$coresVM = [ref]'2'
+			$storageVM = [ref]'100GB'
+			$enabledAddonsList = [System.Collections.ArrayList]@(
+				[pscustomobject]@{ Name = 'logging' }
+			)
+			$hooksBackupPath = [ref]'C:\Backup\Hooks'
+			$logFilePathBeforeUninstall = [ref]'C:\Backup\logfile.log'
+
+			Mock Invoke-ClusterUninstall
+			Mock Enable-AddonFromConfig { throw 'addon enable failed' }
+
+			{ PerformClusterUpgrade -ShowProgress -DeleteFiles -ShowLogs -K2sPathToInstallFrom 'C:\K2sPath' -Config 'config.yaml' -Proxy 'http://proxy' -BackupDir 'C:\Backup' -AdditionalHooksDir 'C:\Hooks' -memoryVM $memoryVM -coresVM $coresVM -storageVM $storageVM -enabledAddonsList $enabledAddonsList -hooksBackupPath $hooksBackupPath -logFilePathBeforeUninstall $logFilePathBeforeUninstall } | Should -Not -Throw
+
+			Should -Invoke Write-Log -Times 1 -Scope It -ParameterFilter { $Messages -match "Warning.*logging" }
 		}
 	}
 }


### PR DESCRIPTION


<!-- Does this PR fix an issue -->

Fixes #2014 

### Motivation

After system upgrade enabled addons were not enabled by default.

### Modifications

Fixed it by exporting Enable-AddonFromConfig method which was private earlier.

### Verification

Manual upgrade testing, addons are retained in enabled state after upgrade.
e2e tests, units tests added newly
no impact to cluster and other usecases

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->