### PR TITLE
Monitoring addon nightly fix

### DIFF
--- a/addons/autoscaling/Enable.ps1
+++ b/addons/autoscaling/Enable.ps1
@@ -86,7 +86,7 @@ if (-not $applyResult.Success) {
 
 $applyResult.Output | Write-Log
 
-$allPodsAreUp = (Wait-ForPodCondition -Condition Ready -Label 'app=keda-operator' -Namespace 'autoscaling' -TimeoutSeconds 120)
+$allPodsAreUp = (Wait-ForPodCondition -Condition Ready -Label 'app=keda-operator' -Namespace 'autoscaling' -TimeoutSeconds 300)
 if ($allPodsAreUp -ne $true) {
     $errMsg = "All KEDA pods could not become ready. Please use kubectl describe for more details.`nInstallation of keda failed."
     if ($EncodeStructuredOutput -eq $true) {

--- a/addons/autoscaling/manifests/keda.yaml
+++ b/addons/autoscaling/manifests/keda.yaml
@@ -10475,7 +10475,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 40
+          initialDelaySeconds: 25
         name: keda-operator
         ports:
         - containerPort: 8080

--- a/addons/autoscaling/manifests/keda.yaml
+++ b/addons/autoscaling/manifests/keda.yaml
@@ -10475,7 +10475,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 25
+          initialDelaySeconds: 40
         name: keda-operator
         ports:
         - containerPort: 8080

--- a/addons/security/security.module.psm1
+++ b/addons/security/security.module.psm1
@@ -120,8 +120,8 @@ function Enable-WindowsSecurityDeployments {
     Invoke-WindowsSecurityYaml -yamlPath $winLoginYamlPath -updatedYamlPath $updatedWinLoginYamlPath
 
     Write-Log 'Waiting for windows security deployments..' -Console
-    $hydraStatus = (Wait-ForPodCondition -Condition Ready -Label 'app=hydra' -Namespace 'security' -TimeoutSeconds 120)
-    $winLoginStatus = (Wait-ForPodCondition -Condition Ready -Label 'app=windows-login' -Namespace 'security' -TimeoutSeconds 120)
+    $hydraStatus = (Wait-ForPodCondition -Condition Ready -Label 'app=hydra' -Namespace 'security' -TimeoutSeconds 300)
+    $winLoginStatus = (Wait-ForPodCondition -Condition Ready -Label 'app=windows-login' -Namespace 'security' -TimeoutSeconds 300)
 
     Write-Log 'Waiting for windows security api to be available..' -Console
     $hydraUrl = 'http://172.19.1.1:4445/admin/clients'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2024 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

<!--

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes autoscaling intermittent timeout issues.

### Motivation

KEDA image pull through proxy causes intermittent timeout failures in nightly CI (2/3 runs fail) because images are not pre-cached.

### Modifications

Increased Wait-ForPodCondition timeout from 120s to 300s in autoscaling addon Enable.ps1.

### Verification

Validated across three consecutive nightly runs; previously failing runs now pass reliably.

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->