### PR TITLE
#2014 Fix: Correct resource restore paths in K2s cluster upgrade

### DIFF
--- a/k2s/test/framework/dsl/addons.go
+++ b/k2s/test/framework/dsl/addons.go
@@ -12,6 +12,8 @@ import (
 )
 
 func (k2s *K2s) IsAddonEnabled(name string, implementation ...string) bool {
+	k2s.suite.SetupInfo().ReloadRuntimeConfig()
+
 	impl := ""
 	if len(implementation) > 0 {
 		impl = implementation[0]

--- a/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.psm1
+++ b/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.psm1
@@ -1428,12 +1428,12 @@ function PerformClusterUpgrade {
 			if ($ShowProgress -eq $true) {
 				Write-Progress -Activity 'Apply not namespaced resources on cluster..' -Id 1 -Status '8/10' -PercentComplete 80 -CurrentOperation 'Apply not namespaced resources, please wait..'
 			}
-			Import-NotNamespacedResources -folderResources $BackupDir -ExePath $kubeExeFolder
+			Import-NotNamespacedResources -folderResources (Join-Path $BackupDir 'NotNamespaced') -ExePath $kubeExeFolder
 			
 			if ($ShowProgress -eq $true) {
 				Write-Progress -Activity 'Apply namespaced resources on cluster..' -Id 1 -Status '8.5/10' -PercentComplete 85 -CurrentOperation 'Apply namespaced resources, please wait..'
 			}
-			Import-NamespacedResources -folderNamespaces $BackupDir -ExePath $kubeExeFolder
+			Import-NamespacedResources -folderNamespaces (Join-Path $BackupDir 'Namespaced') -ExePath $kubeExeFolder
 		}
 
 		# re-enable previously enabled addons

--- a/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.unit.tests.ps1
+++ b/lib/modules/k2s/k2s.cluster.module/upgrade/upgrade.module.unit.tests.ps1
@@ -351,8 +351,8 @@ Describe "PerformClusterUpgrade" -Tag 'unit', 'ci', 'upgrade' {
 			Should -Invoke Invoke-ClusterUninstall -Exactly 1 -Scope It
 			Should -Invoke Invoke-ClusterInstall -Exactly 1 -Scope It
 			Should -Invoke Invoke-UpgradeBackupRestoreHooks -Exactly 1 -Scope It -ParameterFilter { $HookType -eq "Restore" -and $BackupDir -eq $hooksBackupPath.Value }
-			Should -Invoke Import-NotNamespacedResources -Exactly 1 -Scope It
-			Should -Invoke Import-NamespacedResources -Exactly 1 -Scope It
+			Should -Invoke Import-NotNamespacedResources -Exactly 1 -Scope It -ParameterFilter { $folderResources -eq 'C:\Backup\NotNamespaced' }
+			Should -Invoke Import-NamespacedResources -Exactly 1 -Scope It -ParameterFilter { $folderNamespaces -eq 'C:\Backup\Namespaced' }
 			Should -Invoke Restore-LogFile -Exactly 1 -Scope It
 			Should -Invoke Write-Log -Times 1 -Scope It
 			Should -Invoke Write-Progress -Times 1 -Scope It
@@ -375,8 +375,8 @@ Describe "PerformClusterUpgrade" -Tag 'unit', 'ci', 'upgrade' {
 			Should -Invoke  Invoke-ClusterUninstall -Exactly 1 -Scope It
 			Should -Invoke Invoke-ClusterInstall -Exactly 1 -Scope It
 			Should -Invoke Invoke-UpgradeBackupRestoreHooks -Exactly 0 -Scope It -ParameterFilter { $HookType -eq "Restore" -and $BackupDir -eq $hooksBackupPath.Value }
-			Should -Invoke Import-NotNamespacedResources -Exactly 1 -Scope It
-			Should -Invoke Import-NamespacedResources -Exactly 1 -Scope It
+			Should -Invoke Import-NotNamespacedResources -Exactly 1 -Scope It -ParameterFilter { $folderResources -eq 'C:\Backup\NotNamespaced' }
+			Should -Invoke Import-NamespacedResources -Exactly 1 -Scope It -ParameterFilter { $folderNamespaces -eq 'C:\Backup\Namespaced' }
 			Should -Invoke Restore-LogFile -Exactly 1 -Scope It
 			Should -Invoke Write-Log -Times 1 -Scope It
 			Should -Invoke Write-Progress -Times 1 -Scope It


### PR DESCRIPTION
#2014  
Fix: Correct resource restore paths in K2s cluster upgrade

## Problem

During cluster upgrade, user workloads (Deployments, Services, Pods) are lost after the uninstall/reinstall cycle because the restore functions receive the wrong backup directory path.

**Root cause:** `Export-ClusterResources` writes exports into two subdirectories:
- `$BackupDir/NotNamespaced/` for cluster-scoped resources (CRDs, ClusterRoles, etc.)
- `$BackupDir/Namespaced/` for per-namespace resources

However, `PerformClusterUpgrade` was passing the *root* `$BackupDir` to both import functions instead of their dedicated subdirectories.

**Result:** `Import-NamespacedResources` reads `Get-ChildItem -Path $BackupDir -Directory` and sees literal folder names `NotNamespaced` and `Namespaced` as Kubernetes namespace names, tries to create them, gets rejected with "uppercase not allowed in RFC 1123 label", and never processes the real user namespaces inside `$BackupDir/Namespaced/`.


## Solution

Pass the correct subdirectory path to each import function:
