### PR TITLE
Fixing add linux node image pull error 

### DIFF
--- a/cfg/nodeextension/debian12/scripts/install-k8s-packages.sh
+++ b/cfg/nodeextension/debian12/scripts/install-k8s-packages.sh
@@ -154,6 +154,8 @@ if [ -n "$KUBEADM_PAUSE_IMAGE" ]; then
         echo '[crio.image]'
         echo "pause_image = \"$KUBEADM_PAUSE_IMAGE\""
     } | sudo tee /etc/crio/crio.conf.d/20-k2s-kubeadm-pause.conf > /dev/null
+    # Reload first: the cri-o package upgrade may have replaced crio.service on disk
+    sudo systemctl daemon-reload
     sudo systemctl restart crio || true
 else
     echo "[InstallK8s] WARNING: Could not resolve pause image from kubeadm; keeping CRI-O package default"

--- a/cfg/nodeextension/debian13/scripts/install-k8s-packages.sh
+++ b/cfg/nodeextension/debian13/scripts/install-k8s-packages.sh
@@ -154,6 +154,8 @@ if [ -n "$KUBEADM_PAUSE_IMAGE" ]; then
         echo '[crio.image]'
         echo "pause_image = \"$KUBEADM_PAUSE_IMAGE\""
     } | sudo tee /etc/crio/crio.conf.d/20-k2s-kubeadm-pause.conf > /dev/null
+    # Reload first: the cri-o package upgrade may have replaced crio.service on disk
+    sudo systemctl daemon-reload
     sudo systemctl restart crio || true
 else
     echo "[InstallK8s] WARNING: Could not resolve pause image from kubeadm; keeping CRI-O package default"

--- a/lib/scripts/k2s/system/package/New-K2sNodePackage.VmProvisioning.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sNodePackage.VmProvisioning.ps1
@@ -157,10 +157,12 @@ function Start-NodePackageVmProvisioning {
 	}
 	Write-Log "[NodePkg] Using KubeSwitch subnet '$controlPlaneCIDR' with guest IP '$guestIp' and gateway '$hostIp'." -Console
 
-	$loopbackAdapter = Get-L2BridgeName
-	$hostDns = Get-DnsIpAddressesFromActivePhysicalNetworkInterfacesOnWindowsHost -ExcludeNetworkInterfaceName $loopbackAdapter
+	$hostDns = Get-DnsClientServerAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+		ForEach-Object { @($_.ServerAddresses) } |
+		Where-Object { $_ -and $_ -ne '0.0.0.0' -and $_ -notlike '127.*' } |
+		Select-Object -First 1
 	if ([string]::IsNullOrWhiteSpace($hostDns)) {
-		$hostDns = '8.8.8.8,8.8.4.4'
+		$hostDns = '8.8.8.8'
 		Write-Log "[NodePkg] No host DNS detected. Falling back to '$hostDns'." -Console
 	}
 	else {

--- a/lib/scripts/k2s/system/package/New-K2sNodePackage.VmProvisioning.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sNodePackage.VmProvisioning.ps1
@@ -157,12 +157,10 @@ function Start-NodePackageVmProvisioning {
 	}
 	Write-Log "[NodePkg] Using KubeSwitch subnet '$controlPlaneCIDR' with guest IP '$guestIp' and gateway '$hostIp'." -Console
 
-	$hostDns = Get-DnsClientServerAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
-		ForEach-Object { @($_.ServerAddresses) } |
-		Where-Object { $_ -and $_ -ne '0.0.0.0' -and $_ -notlike '127.*' } |
-		Select-Object -First 1
+	$loopbackAdapter = Get-L2BridgeName
+	$hostDns = Get-DnsIpAddressesFromActivePhysicalNetworkInterfacesOnWindowsHost -ExcludeNetworkInterfaceName $loopbackAdapter
 	if ([string]::IsNullOrWhiteSpace($hostDns)) {
-		$hostDns = '8.8.8.8'
+		$hostDns = '8.8.8.8,8.8.4.4'
 		Write-Log "[NodePkg] No host DNS detected. Falling back to '$hostDns'." -Console
 	}
 	else {


### PR DESCRIPTION
Issue : 
The pause-image drop-in is a CRI-O config override that forces CRI-O to use the same pause image that kubeadm expects for the current Kubernetes version.

[18-06-2026 04:33:28] | Msg: [InstallK8s] Configuring CRI-O pause image from kubeadm v1.36.2: registry.k8s.io/pause:3.10.2 | From: [vm.module.psm1](<ScriptBlock>)
[18-06-2026 04:33:28] | Msg: Warning: The unit file, source configuration file or drop-ins of crio.service changed on disk. Run 'systemctl daemon-reload' to reload units. | From: [vm.module.psm1](<ScriptBlock>)

solution : added sudo systemctl daemon-reload in an order.