### PR TITLE
fix: ensure helm and yq are installed in kubemaster

### DIFF
--- a/k2s/test/e2e/cluster/core/core_test.go
+++ b/k2s/test/e2e/cluster/core/core_test.go
@@ -4,12 +4,16 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	contracts "github.com/siemens-healthineers/k2s/internal/contracts/ssh"
+	"github.com/siemens-healthineers/k2s/internal/definitions"
+	"github.com/siemens-healthineers/k2s/internal/providers/ssh"
 	"github.com/siemens-healthineers/k2s/test/framework"
 	"github.com/siemens-healthineers/k2s/test/framework/dsl"
 	"github.com/siemens-healthineers/k2s/test/framework/watcher"
@@ -274,6 +278,29 @@ var _ = Describe("Cluster Core", func() {
 		Describe("System Deployments", func() {
 			It("coredns is available", func() {
 				suite.Cluster().ExpectDeploymentToBeAvailable("coredns", systemNamespace)
+			})
+		})
+
+		Describe("Control Plane Tools", func() {
+			sshExec := func(cmd string) error {
+				var buf bytes.Buffer
+				opts := contracts.ConnectionOptions{
+					IpAddress:         suite.SetupInfo().Config.ControlPlane().IpAddress(),
+					Port:              definitions.SSHDefaultPort,
+					RemoteUser:        definitions.SSHRemoteUser,
+					SshPrivateKeyPath: suite.SetupInfo().Config.Host().SshConfig().CurrentPrivateKeyPath(),
+					Timeout:           time.Minute,
+					StdOutWriter:      &buf,
+				}
+				return ssh.Exec(cmd, opts)
+			}
+
+			It("helm is installed on control-plane", func() {
+				Expect(sshExec("helm version")).To(Succeed())
+			})
+
+			It("yq is installed on control-plane", func() {
+				Expect(sshExec("yq --version")).To(Succeed())
 			})
 		})
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -723,6 +723,8 @@ Function Install-Tools {
     &$executeRemoteCommand 'sudo systemctl daemon-reload'
     &$executeRemoteCommand 'sudo systemctl restart crio'
 
+    Install-HelmAndYqOnKubeMaster -UserName $UserName -UserPwd $UserPwd -IpAddress $IpAddress
+
     Write-Log 'Finished installing tools in Linux'
 
 }
@@ -1658,7 +1660,6 @@ function New-VmImageForControlPlaneNode {
             GatewayIpAddress     = $GatewayIpAddress
         }
         Edit-SupportForWSL @supportForWSLParams
-        Install-HelmAndYqOnKubeMaster -UserName $vmUserName -UserPwd $vmUserPwd -IpAddress $IpAddress
 
         if ($EnableDynamicMemory) {
             $dynamicMemoryParams = @{


### PR DESCRIPTION
During packaging, helm and yq are missed. This PR ensures that before packaging is complete, helm and yq are installed in kubemaster.