### PR TITLE
Proxy Failure in GPU Node Packaging issue fix

### DIFF
--- a/docs/op-manual/extending-k2s-cluster.md
+++ b/docs/op-manual/extending-k2s-cluster.md
@@ -107,24 +107,24 @@ The offline workflow has two phases:
 
 ### 1. Create the node package
 
-Generate an OS-specific node package. This step requires an installed *K2s* cluster on the machine where you run the command, and it must use the local cluster proxy `http://172.19.1.1:8181`.
+Generate an OS-specific node package. This step requires an installed and running *K2s* cluster on the machine where you run the command. The local cluster proxy `http://172.19.1.1:8181` is used by default, so `--proxy` can be omitted; pass `-p` only to override it.
 
 Example using `k2s.exe` directly from a local directory:
 
 ```console
-.\k2s.exe system package --node-package --os debian12 --target-dir "D:\Linuxpackagetest" --name "debian12.zip" --proxy http://172.19.1.1:8181
+.\k2s.exe system package --node-package --os debian12 --target-dir "D:\Linuxpackagetest" --name "debian12.zip"
 ```
 
 You can also generate the package on an existing *K2s* host:
 
 ```console
-k2s system package --node-package --os debian12 --target-dir "C:\out" --name "debian12-node.zip" -p http://172.19.1.1:8181
+k2s system package --node-package --os debian12 --target-dir "C:\out" --name "debian12-node.zip"
 ```
 
 For Debian 13 nodes, create a Debian 13 package instead:
 
 ```console
-k2s system package --node-package --os debian13 --target-dir "C:\out" --name "debian13-node.zip" -p http://172.19.1.1:8181
+k2s system package --node-package --os debian13 --target-dir "C:\out" --name "debian13-node.zip"
 ```
 
 !!! note

--- a/docs/user-guide/gpu-node.md
+++ b/docs/user-guide/gpu-node.md
@@ -230,11 +230,14 @@ If no NVIDIA GPU is detected (or a non-NVIDIA GPU like AMD/Intel is present), GP
 
 For environments without internet access, create a GPU-enabled node package first.
 
-**Step 1: Create the GPU node package** (on a machine with internet)
+**Step 1: Create the GPU node package** (on a machine with an installed and running *K2s* cluster)
 
 ```console
 k2s system package --node-package --os debian13 --include-gpu --target-dir C:\packages --name debian13-gpu.zip
 ```
+
+!!! note
+    Node package creation requires an installed and running *K2s* cluster. The local cluster proxy `http://172.19.1.1:8181` is used by default to download the GPU artifacts, so `--proxy` does not need to be specified; pass `-p` only to override it.
 
 The `--include-gpu` flag downloads and bundles:
 

--- a/docs/user-guide/k2s-cli.md
+++ b/docs/user-guide/k2s-cli.md
@@ -487,22 +487,22 @@ k2s system package [flags]
 | `--master-cpus` | | CPUs for master VM |
 | `--master-memory` | | Memory for master VM |
 | `--master-disk` | | Disk for master VM |
-| `--proxy` | `-p` | HTTP proxy. Required for `--node-package`; use the local cluster proxy `http://172.19.1.1:8181` |
+| `--proxy` | `-p` | HTTP proxy. Optional for `--node-package`; when omitted the local cluster proxy `http://172.19.1.1:8181` is used by default |
 | `--k8s-bins` | | Path to locally built Kubernetes binaries |
-| `--node-package` | | Create a Linux worker node package. Requires an existing *K2s* cluster and `-p http://172.19.1.1:8181` |
+| `--node-package` | | Create a Linux worker node package. Requires an installed and running *K2s* cluster. The local cluster proxy is used by default; override with `-p` if needed |
 | `--os` | | Target Linux distribution for `--node-package`, for example `debian12` or `debian13` |
 | `--include-gpu` | | Include NVIDIA Container Toolkit packages for GPU support. When `k2s node add` uses a package built with this flag, GPU support is auto-configured if an NVIDIA GPU is detected |
 
 Example for node package creation:
 
 ```console
-k2s system package --node-package --os debian12 --target-dir "C:\out" --name "debian12-node.zip" -p http://172.19.1.1:8181
+k2s system package --node-package --os debian12 --target-dir "C:\out" --name "debian12-node.zip"
 ```
 
 Example for node package with GPU support:
 
 ```console
-k2s system package --node-package --os debian13 --include-gpu --target-dir "C:\out" --name "debian13-gpu.zip" -p http://172.19.1.1:8181
+k2s system package --node-package --os debian13 --include-gpu --target-dir "C:\out" --name "debian13-gpu.zip"
 ```
 
 ### system backup
@@ -628,7 +628,7 @@ k2s node add [flags]
 | `--role` | `-r` | Node role (default `worker`) |
 | `--node-package` | `-p` | Path to a node package ZIP for offline installation |
 
-Use `--node-package` together with a node package created through `k2s system package --node-package --os ... -p http://172.19.1.1:8181` on an existing *K2s* cluster when adding a Linux worker node without internet access.
+Use `--node-package` together with a node package created through `k2s system package --node-package --os ...` on an installed *K2s* cluster when adding a Linux worker node without internet access.
 
 ### node remove
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -922,7 +922,9 @@ function Get-GpuContainerImages {
 
     foreach ($image in $images) {
         if (![string]::IsNullOrWhiteSpace($Proxy)) {
-            &$executeRemoteCommand "sudo HTTPS_PROXY=$Proxy HTTP_PROXY=$Proxy buildah pull '$image'"
+            # Normalize proxy URL - strip existing scheme and ensure http:// prefix
+            $proxyHost = $Proxy -replace '^https?://', ''
+            &$executeRemoteCommand "sudo HTTPS_PROXY=http://$proxyHost HTTP_PROXY=http://$proxyHost buildah pull '$image'"
         } else {
             &$executeRemoteCommand "sudo buildah pull '$image'"
         }

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -828,7 +828,9 @@ function Get-NvidiaGpuDebPackagesFromInternet {
     if (![string]::IsNullOrWhiteSpace($Proxy)) {
         $curlProxy = "-x $Proxy"
         Write-Log "[GpuPkg] Configuring apt proxy: $Proxy"
-        $aptProxyCmd = "printf 'Acquire::http::Proxy `"%s`";\nAcquire::https::Proxy `"%s`";\n' '$Proxy' '$Proxy' | sudo tee /etc/apt/apt.conf.d/95k2s-proxy"
+        $aptProxyConf = "Acquire::http::Proxy `"$Proxy`";`nAcquire::https::Proxy `"$Proxy`";`n"
+        $aptProxyConfBase64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($aptProxyConf))
+        $aptProxyCmd = "echo '$aptProxyConfBase64' | base64 -d | sudo tee /etc/apt/apt.conf.d/95k2s-proxy"
         (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $aptProxyCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
     }
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -825,6 +825,7 @@ function Get-NvidiaGpuDebPackagesFromInternet {
 
     Write-Log '[GpuPkg] Downloading NVIDIA Container Toolkit packages'
 
+    $aptProxyConfigured = $false
     $curlProxy = ''
     if (![string]::IsNullOrWhiteSpace($Proxy)) {
         $curlProxy = "-x $Proxy"
@@ -833,34 +834,43 @@ function Get-NvidiaGpuDebPackagesFromInternet {
         $aptProxyConfBase64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($aptProxyConf))
         $aptProxyCmd = "echo '$aptProxyConfBase64' | base64 -d | sudo tee /etc/apt/apt.conf.d/95k2s-proxy"
         (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $aptProxyCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
+        $aptProxyConfigured = $true
     }
 
-    # Add NVIDIA Container Toolkit repository
-    $repoSetupCmd = "curl --retry 3 --retry-all-errors -fsSL https://nvidia.github.io/libnvidia-container/gpgkey $curlProxy | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && curl --retry 3 --retry-all-errors -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list $curlProxy | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list"
-    Write-Log '[GpuPkg] Setting up NVIDIA repository...'
-    (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $repoSetupCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
+    try {
+        # Add NVIDIA Container Toolkit repository
+        $repoSetupCmd = "curl --retry 3 --retry-all-errors -fsSL https://nvidia.github.io/libnvidia-container/gpgkey $curlProxy | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && curl --retry 3 --retry-all-errors -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list $curlProxy | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list"
+        Write-Log '[GpuPkg] Setting up NVIDIA repository...'
+        (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $repoSetupCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
 
-    $updateCmd = 'sudo apt-get update'
-    (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $updateCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
+        $updateCmd = 'sudo apt-get update'
+        (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $updateCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
 
-    # Create target directory
-    (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "mkdir -p $TargetPath && cd $TargetPath && sudo chown -R _apt:root ." -RemoteUser $remoteUser -RemoteUserPwd $UserPwd).Output | Write-Log
+        # Create target directory
+        (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "mkdir -p $TargetPath && cd $TargetPath && sudo chown -R _apt:root ." -RemoteUser $remoteUser -RemoteUserPwd $UserPwd).Output | Write-Log
 
-    $gpuPackages = @('libnvidia-container1', 'libnvidia-container-tools', 'nvidia-container-toolkit-base', 'nvidia-container-runtime', 'nvidia-container-toolkit')
-    foreach ($pkg in $gpuPackages) {
-        Write-Log "[GpuPkg] Downloading GPU package: $pkg"
-        # Download the package
-        $downloadCmd = "cd $TargetPath && sudo apt-get download $pkg 2>&1"
-        (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $downloadCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
-        
-        # Download dependencies
-        $depsCmd = "cd $TargetPath && sudo DEBIAN_FRONTEND=noninteractive apt-get --reinstall install -y --no-install-recommends --no-install-suggests --simulate ./${pkg}*.deb 2>/dev/null | grep 'Inst ' | cut -d ' ' -f 2 | sort -u | xargs -r sudo apt-get download 2>&1 || true"
-        (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $depsCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
+        $gpuPackages = @('libnvidia-container1', 'libnvidia-container-tools', 'nvidia-container-toolkit-base', 'nvidia-container-runtime', 'nvidia-container-toolkit')
+        foreach ($pkg in $gpuPackages) {
+            Write-Log "[GpuPkg] Downloading GPU package: $pkg"
+            # Download the package
+            $downloadCmd = "cd $TargetPath && sudo apt-get download $pkg 2>&1"
+            (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $downloadCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
+            
+            # Download dependencies
+            $depsCmd = "cd $TargetPath && sudo DEBIAN_FRONTEND=noninteractive apt-get --reinstall install -y --no-install-recommends --no-install-suggests --simulate ./${pkg}*.deb 2>/dev/null | grep 'Inst ' | cut -d ' ' -f 2 | sort -u | xargs -r sudo apt-get download 2>&1 || true"
+            (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $depsCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
+        }
+
+        $remoteGpuDebCount = (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "ls -1 $TargetPath/*.deb 2>/dev/null | wc -l" -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output
+        Write-Log "[GpuPkg] GPU packages downloaded: $($remoteGpuDebCount.Trim())"
+        Write-Log '[GpuPkg] Finished downloading NVIDIA Container Toolkit packages'
     }
-
-    $remoteGpuDebCount = (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "ls -1 $TargetPath/*.deb 2>/dev/null | wc -l" -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output
-    Write-Log "[GpuPkg] GPU packages downloaded: $($remoteGpuDebCount.Trim())"
-    Write-Log '[GpuPkg] Finished downloading NVIDIA Container Toolkit packages'
+    finally {
+        if ($aptProxyConfigured) {
+            Write-Log '[GpuPkg] Removing temporary apt proxy configuration (/etc/apt/apt.conf.d/95k2s-proxy)'
+            (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute 'sudo rm -f /etc/apt/apt.conf.d/95k2s-proxy' -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
+        }
+    }
 }
 
 <#

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -824,11 +824,12 @@ function Get-NvidiaGpuDebPackagesFromInternet {
 
     Write-Log '[GpuPkg] Downloading NVIDIA Container Toolkit packages'
 
-    $proxyEnv = ''
     $curlProxy = ''
     if (![string]::IsNullOrWhiteSpace($Proxy)) {
-        $proxyEnv = "http_proxy=$Proxy https_proxy=$Proxy "
         $curlProxy = "-x $Proxy"
+        Write-Log "[GpuPkg] Configuring apt proxy: $Proxy"
+        $aptProxyCmd = "printf 'Acquire::http::Proxy `"%s`";\nAcquire::https::Proxy `"%s`";\n' '$Proxy' '$Proxy' | sudo tee /etc/apt/apt.conf.d/95k2s-proxy"
+        (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $aptProxyCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
     }
 
     # Add NVIDIA Container Toolkit repository
@@ -836,8 +837,7 @@ function Get-NvidiaGpuDebPackagesFromInternet {
     Write-Log '[GpuPkg] Setting up NVIDIA repository...'
     (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $repoSetupCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
 
-    # Update apt
-    $updateCmd = "${proxyEnv}sudo apt-get update"
+    $updateCmd = 'sudo apt-get update'
     (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $updateCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
 
     # Create target directory
@@ -847,11 +847,11 @@ function Get-NvidiaGpuDebPackagesFromInternet {
     foreach ($pkg in $gpuPackages) {
         Write-Log "[GpuPkg] Downloading GPU package: $pkg"
         # Download the package
-        $downloadCmd = "cd $TargetPath && ${proxyEnv}sudo apt-get download $pkg 2>&1"
+        $downloadCmd = "cd $TargetPath && sudo apt-get download $pkg 2>&1"
         (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $downloadCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
         
         # Download dependencies
-        $depsCmd = "cd $TargetPath && ${proxyEnv}sudo DEBIAN_FRONTEND=noninteractive apt-get --reinstall install -y --no-install-recommends --no-install-suggests --simulate ./${pkg}*.deb 2>/dev/null | grep 'Inst ' | cut -d ' ' -f 2 | sort -u | xargs -r ${proxyEnv}sudo apt-get download 2>&1 || true"
+        $depsCmd = "cd $TargetPath && sudo DEBIAN_FRONTEND=noninteractive apt-get --reinstall install -y --no-install-recommends --no-install-suggests --simulate ./${pkg}*.deb 2>/dev/null | grep 'Inst ' | cut -d ' ' -f 2 | sort -u | xargs -r sudo apt-get download 2>&1 || true"
         (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $depsCmd -RemoteUser $remoteUser -RemoteUserPwd $UserPwd -IgnoreErrors).Output | Write-Log
     }
 
@@ -880,7 +880,8 @@ function Get-GpuContainerImages {
         [string]$UserName = $(throw 'Argument missing: UserName'),
         [string]$UserPwd = $(throw 'Argument missing: UserPwd'),
         [ValidateScript({ Get-IsValidIPv4Address($_) })]
-        [string]$IpAddress = $(throw 'Argument missing: IpAddress')
+        [string]$IpAddress = $(throw 'Argument missing: IpAddress'),
+        [string]$Proxy = ''
     )
     $remoteUser = "$UserName@$IpAddress"
     $remoteUserPwd = $UserPwd
@@ -891,8 +892,16 @@ function Get-GpuContainerImages {
 
     Write-Log '[GpuImg] Pulling GPU container images (device plugin, DCGM exporter)'
 
-    &$executeRemoteCommand 'sudo buildah pull nvcr.io/nvidia/k8s-device-plugin:v0.19.1'
-    &$executeRemoteCommand 'sudo buildah pull nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubi9'
+    # Proxy env vars must be placed AFTER 'sudo': sudo sanitizes the environment and drops
+    # variables set as a prefix before it, which would leave buildah without a proxy and make
+    # it fail to resolve the external registry (nvcr.io).
+    $proxyEnv = ''
+    if (![string]::IsNullOrWhiteSpace($Proxy)) {
+        $proxyEnv = "http_proxy=$Proxy https_proxy=$Proxy HTTP_PROXY=$Proxy HTTPS_PROXY=$Proxy "
+    }
+
+    &$executeRemoteCommand "sudo ${proxyEnv}buildah pull nvcr.io/nvidia/k8s-device-plugin:v0.19.1"
+    &$executeRemoteCommand "sudo ${proxyEnv}buildah pull nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubi9"
 
     Write-Log '[GpuImg] Finished pulling GPU container images'
 }

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -893,18 +893,40 @@ function Get-GpuContainerImages {
         (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute $Command -RemoteUser "$remoteUser" -RemoteUserPwd "$remoteUserPwd").Output | Write-Log
     }
 
-    Write-Log '[GpuImg] Pulling GPU container images (device plugin, DCGM exporter)'
-
-    # Proxy env vars must be placed AFTER 'sudo': sudo sanitizes the environment and drops
-    # variables set as a prefix before it, which would leave buildah without a proxy and make
-    # it fail to resolve the external registry (nvcr.io).
-    $proxyEnv = ''
-    if (![string]::IsNullOrWhiteSpace($Proxy)) {
-        $proxyEnv = "http_proxy=$Proxy https_proxy=$Proxy HTTP_PROXY=$Proxy HTTPS_PROXY=$Proxy "
+    # Resolve manifest path relative to this module's location
+    $repoRoot = (Get-Item -Path $PSScriptRoot).Parent.Parent.Parent.Parent.Parent.Parent.FullName
+    $manifestPath = Join-Path -Path $repoRoot -ChildPath 'addons\gpu-node\addon.manifest.yaml'
+    
+    if (!(Test-Path -Path $manifestPath)) {
+        throw "[GpuImg] GPU addon manifest not found at: $manifestPath"
     }
+    
+    $manifestContent = Get-Content -Path $manifestPath -Raw
+    if ([string]::IsNullOrWhiteSpace($manifestContent)) {
+        throw "[GpuImg] GPU addon manifest is empty: $manifestPath"
+    }
+    
+    $images = @([regex]::Matches($manifestContent, 'nvcr\.io/nvidia/[A-Za-z0-9_./-]+:[A-Za-z0-9_.-]+') | ForEach-Object { $_.Value } | Select-Object -Unique)
 
-    &$executeRemoteCommand "sudo ${proxyEnv}buildah pull nvcr.io/nvidia/k8s-device-plugin:v0.19.1"
-    &$executeRemoteCommand "sudo ${proxyEnv}buildah pull nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubi9"
+    if ($images.Count -eq 0) {
+        Write-Log '[GpuImg] No NVIDIA container images found in addon manifest (GPU addon may not be updated)' -Console
+        return
+    }
+    
+    $devicePluginVersion = ($images | Where-Object { $_ -match '^nvcr\.io/nvidia/k8s-device-plugin:' } | Select-Object -First 1) -replace '^.*:', ''
+    $dcgmExporterVersion = ($images | Where-Object { $_ -match '^nvcr\.io/nvidia/k8s/dcgm-exporter:' } | Select-Object -First 1) -replace '^.*:', ''
+
+    Write-Log "[GpuImg] k8s-device-plugin version from addon manifest: $devicePluginVersion"
+    Write-Log "[GpuImg] dcgm-exporter version from addon manifest: $dcgmExporterVersion"
+    Write-Log "[GpuImg] Pulling GPU container images from addon manifest: $($images -join ', ')"
+
+    foreach ($image in $images) {
+        if (![string]::IsNullOrWhiteSpace($Proxy)) {
+            &$executeRemoteCommand "sudo HTTPS_PROXY=$Proxy HTTP_PROXY=$Proxy buildah pull '$image'"
+        } else {
+            &$executeRemoteCommand "sudo buildah pull '$image'"
+        }
+    }
 
     Write-Log '[GpuImg] Finished pulling GPU container images'
 }

--- a/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/distros/common-setup.module.psm1
@@ -556,6 +556,7 @@ Function Remove-KubernetesArtifacts {
     &$executeRemoteCommand 'sudo rm -f /etc/sysctl.d/k8s.conf'
     &$executeRemoteCommand 'sudo rm -f /etc/modules-load.d/k8s.conf'
     &$executeRemoteCommand 'sudo sysctl --system'
+    &$executeRemoteCommand 'sudo rm -f /etc/apt/apt.conf.d/95k2s-proxy'
 
     &$executeRemoteCommand 'sudo DEBIAN_FRONTEND=noninteractive dpkg -P cri-o' 
     &$executeRemoteCommand 'sudo DEBIAN_FRONTEND=noninteractive dpkg -P buildah' 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
@@ -183,8 +183,6 @@ function Install-NvidiaContainerToolkitOnline {
 
     Write-Log "[GPU] Installing NVIDIA Container Toolkit (online) on $IpAddress" -Console
 
-    # If no proxy specified, use K2s's HTTP proxy (same as gpu-node addon)
-    # Worker nodes on the internal K2s network need the proxy to reach the internet
     if ([string]::IsNullOrWhiteSpace($Proxy)) {
         $kubeSwitchIp = Get-ConfiguredKubeSwitchIP
         if (![string]::IsNullOrWhiteSpace($kubeSwitchIp)) {
@@ -193,12 +191,12 @@ function Install-NvidiaContainerToolkitOnline {
         }
     }
 
-    $proxyEnv = ''
     $curlProxy = ''
     if (![string]::IsNullOrWhiteSpace($Proxy)) {
-        # apt-get requires full URL with http:// prefix for proxy environment variables
-        $proxyEnv = "http_proxy=http://$Proxy https_proxy=http://$Proxy "
         $curlProxy = "-x $Proxy"
+        Write-Log "[GPU] Configuring apt proxy: http://$Proxy"
+        $aptProxyCmd = "printf 'Acquire::http::Proxy `"%s`";\nAcquire::https::Proxy `"%s`";\n' 'http://$Proxy' 'http://$Proxy' | sudo tee /etc/apt/apt.conf.d/95k2s-proxy"
+        (Invoke-CmdOnVmViaSSHKey -CmdToExecute $aptProxyCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors).Output | Write-Log
     }
 
     Write-Log "[GPU] Setting up NVIDIA apt repository (proxy='$Proxy')" -Console
@@ -214,10 +212,11 @@ function Install-NvidiaContainerToolkitOnline {
     $verifySourcesCmd = 'cat /etc/apt/sources.list.d/nvidia-container-toolkit.list 2>/dev/null || echo "FILE_NOT_FOUND"'
     $verifyResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $verifySourcesCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors
 
-    $updateCmd = "${proxyEnv}sudo apt-get update"
+    # Proxy is taken from /etc/apt/apt.conf.d/95k2s-proxy when configured above
+    $updateCmd = 'sudo apt-get update'
     (Invoke-CmdOnVmViaSSHKey -CmdToExecute $updateCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors).Output | Write-Log
 
-    $installCmd = "${proxyEnv}sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libnvidia-container1 libnvidia-container-tools nvidia-container-runtime nvidia-container-toolkit"
+    $installCmd = 'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libnvidia-container1 libnvidia-container-tools nvidia-container-runtime nvidia-container-toolkit'
     $installResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $installCmd -UserName $UserName -IpAddress $IpAddress
     $installResult.Output | Write-Log
 
@@ -328,7 +327,7 @@ function Install-GpuDevicePluginImages {
         }
     }
 
-    # Build proxy environment if provided
+    # Build proxy environment if provided.
     $proxyEnv = ''
     if (![string]::IsNullOrWhiteSpace($Proxy)) {
         $proxyEnv = "HTTPS_PROXY=http://$Proxy HTTP_PROXY=http://$Proxy "
@@ -346,14 +345,14 @@ function Install-GpuDevicePluginImages {
         Write-Log "[GPU] Pulling image: $image" -Console
 
         # Try buildah pull (shares storage with CRI-O)
-        $pullCmd = "${proxyEnv}sudo buildah pull '$image' 2>&1"
+        $pullCmd = "sudo ${proxyEnv}buildah pull '$image' 2>&1"
         $pullResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $pullCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors
         $pullResult.Output | Write-Log
 
         if (!$pullResult.Success) {
             # Fallback: try crictl pull
             Write-Log "[GPU] buildah pull failed, trying crictl pull..." -Console
-            $crictlCmd = "${proxyEnv}sudo crictl pull '$image' 2>&1"
+            $crictlCmd = "sudo ${proxyEnv}crictl pull '$image' 2>&1"
             $crictlResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $crictlCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors
             $crictlResult.Output | Write-Log
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
@@ -254,6 +254,10 @@ function Install-NvidiaContainerToolkitOnline {
 
         $verifySourcesCmd = 'cat /etc/apt/sources.list.d/nvidia-container-toolkit.list 2>/dev/null || echo "FILE_NOT_FOUND"'
         $verifyResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $verifySourcesCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors
+        $verifyResult.Output | Write-Log
+        if ($verifyResult.Output -match 'FILE_NOT_FOUND') {
+            Write-Log '[GPU] WARNING: NVIDIA repository file /etc/apt/sources.list.d/nvidia-container-toolkit.list was not created.' -Console
+        }
 
         # Proxy is taken from /etc/apt/apt.conf.d/95k2s-proxy when configured above
         $updateCmd = 'sudo apt-get update'

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
@@ -195,7 +195,9 @@ function Install-NvidiaContainerToolkitOnline {
     if (![string]::IsNullOrWhiteSpace($Proxy)) {
         $curlProxy = "-x $Proxy"
         Write-Log "[GPU] Configuring apt proxy: http://$Proxy"
-        $aptProxyCmd = "printf 'Acquire::http::Proxy `"%s`";\nAcquire::https::Proxy `"%s`";\n' 'http://$Proxy' 'http://$Proxy' | sudo tee /etc/apt/apt.conf.d/95k2s-proxy"
+        $aptProxyConf = "Acquire::http::Proxy `"http://$Proxy`";`nAcquire::https::Proxy `"http://$Proxy`";`n"
+        $aptProxyConfBase64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($aptProxyConf))
+        $aptProxyCmd = "echo '$aptProxyConfBase64' | base64 -d | sudo tee /etc/apt/apt.conf.d/95k2s-proxy"
         (Invoke-CmdOnVmViaSSHKey -CmdToExecute $aptProxyCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors).Output | Write-Log
     }
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
@@ -205,7 +205,9 @@ Then use:
 .PARAMETER IpAddress
     IP address of the remote node.
 .PARAMETER Proxy
-    Optional HTTP proxy as 'host:port' WITHOUT a scheme (e.g. '172.19.1.1:8181').
+    Optional HTTP proxy URI (for example 'http://172.19.1.1:8181').
+    For backward compatibility, values provided as 'host:port' are also accepted
+    and normalized to 'http://host:port'.
 #>
 function Install-NvidiaContainerToolkitOnline {
     param (
@@ -225,6 +227,11 @@ function Install-NvidiaContainerToolkitOnline {
             $Proxy = "http://${kubeSwitchIp}:8181"
             Write-Log "[GPU] Using K2s HTTP proxy: $Proxy"
         }
+    }
+
+    if (![string]::IsNullOrWhiteSpace($Proxy) -and ($Proxy -notmatch '^https?://')) {
+        $Proxy = "http://$Proxy"
+        Write-Log "[GPU] Normalized proxy to URI format: $Proxy"
     }
 
     $aptProxyConfigured = $false
@@ -374,7 +381,7 @@ function Install-GpuDevicePluginImages {
     if ([string]::IsNullOrWhiteSpace($Proxy)) {
         $kubeSwitchIp = Get-ConfiguredKubeSwitchIP
         if (![string]::IsNullOrWhiteSpace($kubeSwitchIp)) {
-            $Proxy = "${kubeSwitchIp}:8181"
+            $Proxy = "http://${kubeSwitchIp}:8181"
             Write-Log "[GPU] Using K2s HTTP proxy for image pulls: $Proxy"
         }
     }

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
@@ -170,6 +170,12 @@ Then use:
 <#
 .SYNOPSIS
     Installs NVIDIA Container Toolkit packages from the internet.
+.PARAMETER UserName
+    SSH username for the remote node.
+.PARAMETER IpAddress
+    IP address of the remote node.
+.PARAMETER Proxy
+    Optional HTTP proxy as 'host:port' WITHOUT a scheme (e.g. '172.19.1.1:8181').
 #>
 function Install-NvidiaContainerToolkitOnline {
     param (
@@ -191,6 +197,9 @@ function Install-NvidiaContainerToolkitOnline {
         }
     }
 
+    $Proxy = $Proxy -replace '^https?://', ''
+
+    $aptProxyConfigured = $false
     $curlProxy = ''
     if (![string]::IsNullOrWhiteSpace($Proxy)) {
         $curlProxy = "-x $Proxy"
@@ -199,31 +208,42 @@ function Install-NvidiaContainerToolkitOnline {
         $aptProxyConfBase64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($aptProxyConf))
         $aptProxyCmd = "echo '$aptProxyConfBase64' | base64 -d | sudo tee /etc/apt/apt.conf.d/95k2s-proxy"
         (Invoke-CmdOnVmViaSSHKey -CmdToExecute $aptProxyCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors).Output | Write-Log
+        $aptProxyConfigured = $true
     }
 
-    Write-Log "[GPU] Setting up NVIDIA apt repository (proxy='$Proxy')" -Console
-    
-    $repoSetupCmd = "curl --retry 3 --retry-all-errors -fsSL https://nvidia.github.io/libnvidia-container/gpgkey $curlProxy | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && curl --retry 3 --retry-all-errors -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list $curlProxy | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list"
-    
-    $repoResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $repoSetupCmd -UserName $UserName -IpAddress $IpAddress
-    Write-Log "[GPU] Repo setup result - Success: $($repoResult.Success), Output: $($repoResult.Output)"
-    if (!$repoResult.Success) {
-        throw "[GPU] Failed to set up NVIDIA repository on $IpAddress. Ensure the node has internet access or use --node-package for offline installation."
+    try {
+        Write-Log "[GPU] Setting up NVIDIA apt repository (proxy='$Proxy')" -Console
+
+        $repoSetupCmd = "curl --retry 3 --retry-all-errors -fsSL https://nvidia.github.io/libnvidia-container/gpgkey $curlProxy | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && curl --retry 3 --retry-all-errors -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list $curlProxy | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list"
+
+        $repoResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $repoSetupCmd -UserName $UserName -IpAddress $IpAddress
+        Write-Log "[GPU] Repo setup result - Success: $($repoResult.Success), Output: $($repoResult.Output)"
+        if (!$repoResult.Success) {
+            throw "[GPU] Failed to set up NVIDIA repository on $IpAddress. Ensure the node has internet access or use --node-package for offline installation."
+        }
+
+        $verifySourcesCmd = 'cat /etc/apt/sources.list.d/nvidia-container-toolkit.list 2>/dev/null || echo "FILE_NOT_FOUND"'
+        $verifyResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $verifySourcesCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors
+
+        # Proxy is taken from /etc/apt/apt.conf.d/95k2s-proxy when configured above
+        $updateCmd = 'sudo apt-get update'
+        (Invoke-CmdOnVmViaSSHKey -CmdToExecute $updateCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors).Output | Write-Log
+
+        $installCmd = 'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libnvidia-container1 libnvidia-container-tools nvidia-container-runtime nvidia-container-toolkit'
+        $installResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $installCmd -UserName $UserName -IpAddress $IpAddress
+        $installResult.Output | Write-Log
+
+        if (!$installResult.Success) {
+            throw "[GPU] Failed to install NVIDIA Container Toolkit packages on $IpAddress"
+        }
     }
-
-    $verifySourcesCmd = 'cat /etc/apt/sources.list.d/nvidia-container-toolkit.list 2>/dev/null || echo "FILE_NOT_FOUND"'
-    $verifyResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $verifySourcesCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors
-
-    # Proxy is taken from /etc/apt/apt.conf.d/95k2s-proxy when configured above
-    $updateCmd = 'sudo apt-get update'
-    (Invoke-CmdOnVmViaSSHKey -CmdToExecute $updateCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors).Output | Write-Log
-
-    $installCmd = 'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libnvidia-container1 libnvidia-container-tools nvidia-container-runtime nvidia-container-toolkit'
-    $installResult = Invoke-CmdOnVmViaSSHKey -CmdToExecute $installCmd -UserName $UserName -IpAddress $IpAddress
-    $installResult.Output | Write-Log
-
-    if (!$installResult.Success) {
-        throw "[GPU] Failed to install NVIDIA Container Toolkit packages on $IpAddress"
+    finally {
+        # Remove the temporary apt proxy config so future apt operations on this
+        # (potentially long-lived) node do not depend on the K2s proxy being reachable.
+        if ($aptProxyConfigured) {
+            Write-Log '[GPU] Removing temporary apt proxy configuration (/etc/apt/apt.conf.d/95k2s-proxy)'
+            (Invoke-CmdOnVmViaSSHKey -CmdToExecute 'sudo rm -f /etc/apt/apt.conf.d/95k2s-proxy' -UserName $UserName -IpAddress $IpAddress -IgnoreErrors).Output | Write-Log
+        }
     }
 }
 

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
@@ -380,7 +380,9 @@ function Install-GpuDevicePluginImages {
     # Build proxy environment if provided.
     $proxyEnv = ''
     if (![string]::IsNullOrWhiteSpace($Proxy)) {
-        $proxyEnv = "HTTPS_PROXY=http://$Proxy HTTP_PROXY=http://$Proxy "
+        # Normalize proxy URL - strip existing scheme to avoid duplication
+        $proxyHost = $Proxy -replace '^https?://', ''
+        $proxyEnv = "HTTPS_PROXY=http://$proxyHost HTTP_PROXY=http://$proxyHost "
     }
 
     foreach ($image in $images) {

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
@@ -222,19 +222,17 @@ function Install-NvidiaContainerToolkitOnline {
     if ([string]::IsNullOrWhiteSpace($Proxy)) {
         $kubeSwitchIp = Get-ConfiguredKubeSwitchIP
         if (![string]::IsNullOrWhiteSpace($kubeSwitchIp)) {
-            $Proxy = "${kubeSwitchIp}:8181"
+            $Proxy = "http://${kubeSwitchIp}:8181"
             Write-Log "[GPU] Using K2s HTTP proxy: $Proxy"
         }
     }
-
-    $Proxy = $Proxy -replace '^https?://', ''
 
     $aptProxyConfigured = $false
     $curlProxy = ''
     if (![string]::IsNullOrWhiteSpace($Proxy)) {
         $curlProxy = "-x $Proxy"
-        Write-Log "[GPU] Configuring apt proxy: http://$Proxy"
-        $aptProxyConf = "Acquire::http::Proxy `"http://$Proxy`";`nAcquire::https::Proxy `"http://$Proxy`";`n"
+        Write-Log "[GPU] Configuring apt proxy: $Proxy"
+        $aptProxyConf = "Acquire::http::Proxy `"$Proxy`";`nAcquire::https::Proxy `"$Proxy`";`n"
         $aptProxyConfBase64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($aptProxyConf))
         $aptProxyCmd = "echo '$aptProxyConfBase64' | base64 -d | sudo tee /etc/apt/apt.conf.d/95k2s-proxy"
         (Invoke-CmdOnVmViaSSHKey -CmdToExecute $aptProxyCmd -UserName $UserName -IpAddress $IpAddress -IgnoreErrors).Output | Write-Log

--- a/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/setup/gpu-worker.module.psm1
@@ -28,6 +28,36 @@ Import-Module $infraModule, $clusterModule
 $script:GpuLabelKey = 'gpu'
 $script:AcceleratorLabel = 'accelerator'
 
+function Get-GpuAddonNvidiaImages {
+    $repoRoot = (Get-Item -Path $PSScriptRoot).Parent.Parent.Parent.Parent.Parent.Parent.FullName
+    $manifestPath = Join-Path -Path $repoRoot -ChildPath 'addons\gpu-node\addon.manifest.yaml'
+    
+    if (!(Test-Path -Path $manifestPath)) {
+        throw "[GPU] GPU addon manifest not found at: $manifestPath"
+    }
+    
+    $manifestContent = Get-Content -Path $manifestPath -Raw
+    if ([string]::IsNullOrWhiteSpace($manifestContent)) {
+        throw "[GPU] GPU addon manifest is empty: $manifestPath"
+    }
+    
+    $imageMatches = [regex]::Matches($manifestContent, 'nvcr\.io/nvidia/[A-Za-z0-9_./-]+:[A-Za-z0-9_.-]+')
+    $images = @($imageMatches | ForEach-Object { $_.Value } | Select-Object -Unique)
+
+    if ($images.Count -eq 0) {
+        throw "[GPU] No NVIDIA container images found in addon manifest at: $manifestPath"
+    }
+    
+    $devicePluginVersion = ($images | Where-Object { $_ -match '^nvcr\.io/nvidia/k8s-device-plugin:' } | Select-Object -First 1) -replace '^.*:', ''
+    $dcgmExporterVersion = ($images | Where-Object { $_ -match '^nvcr\.io/nvidia/k8s/dcgm-exporter:' } | Select-Object -First 1) -replace '^.*:', ''
+
+    Write-Log "[GPU] k8s-device-plugin version from addon manifest: $devicePluginVersion" -Console
+    Write-Log "[GPU] dcgm-exporter version from addon manifest: $dcgmExporterVersion" -Console
+    Write-Log "[GPU] Using NVIDIA images from addon manifest: $($images -join ', ')"
+
+    return $images
+}
+
 <#
 .SYNOPSIS
     Installs and configures the NVIDIA Container Toolkit on the target Linux node.
@@ -334,11 +364,9 @@ function Install-GpuDevicePluginImages {
 
     Write-Log "[GPU] Ensuring device plugin images are available on $IpAddress" -Console
 
-    # Images required for GPU support (same as Enable.ps1)
-    $images = @(
-        'nvcr.io/nvidia/k8s-device-plugin:v0.19.1'
-        'nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubi9'
-    )
+    # Resolve image versions from gpu-node addon manifest so automation that scans
+    # addon files (Enable.ps1/addon.manifest.yaml) stays the source of truth.
+    $images = Get-GpuAddonNvidiaImages
 
     # If no proxy specified, use K2s's HTTP proxy
     if ([string]::IsNullOrWhiteSpace($Proxy)) {

--- a/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
@@ -28,19 +28,20 @@
     File name for the resulting zip archive (must end in .zip).
 
 .PARAMETER Proxy
-    HTTP proxy to use for package downloads inside the VM. For node package creation, use
-    the local cluster proxy http://172.19.1.1:8181.
+    Optional HTTP proxy to use for package downloads inside the VM. When omitted, the
+    local cluster transparent proxy (http://<KubeSwitchIP>:8181, e.g. http://172.19.1.1:8181)
+    is used by default. Node package creation requires an installed and running K2s cluster.
 
 .PARAMETER ShowLogs
     When set, all log output is also printed to the console.
 
 .EXAMPLE
-    # Download Debian 12 node packages
-    k2s system package --node-package --os debian12 --target-dir "C:\out" --name "debian12-node.zip" -p http://172.19.1.1:8181
+    # Download Debian 12 node packages (uses the cluster proxy by default)
+    k2s system package --node-package --os debian12 --target-dir "C:\out" --name "debian12-node.zip"
 
 .EXAMPLE
-    # Download Debian 13 node packages through the local cluster proxy
-    k2s system package --node-package --os debian13 --target-dir "C:\out" --name "debian13-node.zip" -p http://172.19.1.1:8181
+    # Download Debian 13 node packages (uses the cluster proxy by default)
+    k2s system package --node-package --os debian13 --target-dir "C:\out" --name "debian13-node.zip"
 #>
 
 param (

--- a/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
@@ -13,7 +13,8 @@
     apt-get download, copies the packages back to the Windows host, and creates a zip archive.
 
     Node package creation requires an existing K2s cluster on the machine where the command
-    runs and the local cluster proxy http://172.19.1.1:8181.
+    runs. When -Proxy is omitted, the local cluster proxy
+    (http://<KubeSwitchIP>:8181, e.g. http://172.19.1.1:8181) is used automatically.
 
     The -TargetDirectory and -ZipPackageFileName flags are required and control
     where the resulting zip is written and what it is named.
@@ -109,7 +110,11 @@ if ($systemError) {
 }
 
 if ([string]::IsNullOrWhiteSpace($Proxy)) {
-    $Proxy = "http://$(Get-ConfiguredKubeSwitchIP):8181"
+    $kubeSwitchIp = Get-ConfiguredKubeSwitchIP
+    if ([string]::IsNullOrWhiteSpace($kubeSwitchIp)) {
+        throw '[NodePkg] Could not determine KubeSwitch IP for default proxy.'
+    }
+    $Proxy = "http://${kubeSwitchIp}:8181"
     Write-Log "[NodePkg] No proxy specified. Defaulting to K2s transparent proxy '$Proxy'." -Console
 }
 

--- a/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
@@ -109,6 +109,24 @@ if ($systemError) {
     exit 1
 }
 
+# Clean up stale node-package NATs and switches from previous failed runs.
+# Without this, random subnet selection can collide with a stale NAT/route,
+# causing New-NetIPAddress to fail and host-to-VM SSH to time out.
+$staleNetworkNamePattern = 'k2s-nodepkg-debian*'
+Write-Log "[NodePkg] Cleaning stale network artifacts matching '$staleNetworkNamePattern'" -Console
+Get-NetNat -ErrorAction SilentlyContinue |
+    Where-Object Name -like $staleNetworkNamePattern |
+    ForEach-Object {
+        Write-Log "[NodePkg] Removing stale NetNat '$($_.Name)'"
+        Remove-NetNat -Name $_.Name -Confirm:$false -ErrorAction SilentlyContinue
+    }
+Get-VMSwitch -ErrorAction SilentlyContinue |
+    Where-Object Name -like $staleNetworkNamePattern |
+    ForEach-Object {
+        Write-Log "[NodePkg] Removing stale VMSwitch '$($_.Name)'"
+        Remove-VMSwitch -Name $_.Name -Force -ErrorAction SilentlyContinue
+    }
+
 if ([string]::IsNullOrWhiteSpace($Proxy)) {
     $kubeSwitchIp = Get-ConfiguredKubeSwitchIP
     if ([string]::IsNullOrWhiteSpace($kubeSwitchIp)) {

--- a/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
@@ -71,10 +71,11 @@ param (
 
 $infraModule = "$PSScriptRoot/../../../../modules/k2s/k2s.infra.module/k2s.infra.module.psm1"
 $nodeModule  = "$PSScriptRoot/../../../../modules/k2s/k2s.node.module/k2s.node.module.psm1"
+$clusterModule = "$PSScriptRoot/../../../../modules/k2s/k2s.cluster.module/k2s.cluster.module.psm1"
 $vmProvisioningHelper = "$PSScriptRoot\New-K2sNodePackage.VmProvisioning.ps1"
 $puttyToolsHelper = "$PSScriptRoot\New-K2sPackage.PuttyTools.ps1"
 
-Import-Module $infraModule, $nodeModule
+Import-Module $infraModule, $nodeModule, $clusterModule
 . $vmProvisioningHelper
 . $puttyToolsHelper
 
@@ -91,18 +92,24 @@ Write-Log "[NodePkg] Distribution key: $distributionKey" -Console
 Write-Log "[NodePkg] Target directory: $TargetDirectory" -Console
 Write-Log "[NodePkg] Output zip: $ZipPackageFileName" -Console
 
-# Clean up stale node-package NATs and switches from previous failed runs.
-# Without this, random subnet selection can collide with a stale NAT/route,
-# causing New-NetIPAddress to silently fail so the host cannot reach the VM (SSH timeout).
-$staleNetworkNamePattern = 'k2s-nodepkg-debian*'
-Write-Log "[NodePkg] Cleaning up stale NATs and switches matching '$staleNetworkNamePattern' from previous runs..." -Console
-Get-NetNat | Where-Object Name -like $staleNetworkNamePattern | ForEach-Object {
-    Write-Log "[NodePkg] Removing stale NAT: $($_.Name) ($($_.InternalIPInterfaceAddressPrefix))" -Console
-    Remove-NetNat -Name $_.Name -Confirm:$false -ErrorAction SilentlyContinue
+# ---------------------------------------------------------------------------
+# Pre-check: node package creation requires a running K2s cluster. The cluster
+# provides the transparent proxy (httpproxy.exe) at <KubeSwitchIP>:8181 that the
+# ephemeral VM uses to download packages from the internet. Fail fast otherwise.
+# ---------------------------------------------------------------------------
+$systemError = Test-SystemAvailability -Structured
+if ($systemError) {
+    if ($EncodeStructuredOutput -eq $true) {
+        Send-ToCli -MessageType $MessageType -Message @{Error = $systemError }
+        return
+    }
+    Write-Log $systemError.Message -Error
+    exit 1
 }
-Get-VMSwitch | Where-Object Name -like $staleNetworkNamePattern | ForEach-Object {
-    Write-Log "[NodePkg] Removing stale vSwitch: $($_.Name)" -Console
-    Remove-VMSwitch -Name $_.Name -Force -ErrorAction SilentlyContinue
+
+if ([string]::IsNullOrWhiteSpace($Proxy)) {
+    $Proxy = "http://$(Get-ConfiguredKubeSwitchIP):8181"
+    Write-Log "[NodePkg] No proxy specified. Defaulting to K2s transparent proxy '$Proxy'." -Console
 }
 
 # Initialize variables for VM and network provisioning

--- a/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sNodePackage.ps1
@@ -288,7 +288,8 @@ try {
         Get-GpuContainerImages `
             -UserName  $sshUser `
             -UserPwd   $sshPwd `
-            -IpAddress $guestIp
+            -IpAddress $guestIp `
+            -Proxy     $Proxy
     }
 
     (Invoke-CmdOnControlPlaneViaUserAndPwd -CmdToExecute "mkdir -p $remoteImagesExportDir" -RemoteUser $remoteUser -RemoteUserPwd $sshPwd -IgnoreErrors).Output | Write-Log

--- a/lib/scripts/worker/linux/common/LinuxWorkerNode.Common.ps1
+++ b/lib/scripts/worker/linux/common/LinuxWorkerNode.Common.ps1
@@ -115,8 +115,9 @@ function Get-LinuxWorkerNodeProvisioningContext {
     Write-Log $osMessage -Console
     Test-SupportedWorkerOS -OS $installedDistribution
 
-    $clusterState = (Invoke-Kubectl -Params @('get', 'nodes', '-o', 'wide')).Output
-    if ($clusterState -match $k8sFormattedNodeName) {
+    # Check only node names (not entire output) to avoid false positives from OS-IMAGE column
+    $existingNodeNames = @((Invoke-Kubectl -Params @('get', 'nodes', '-o', 'jsonpath={.items[*].metadata.name}')).Output -split '\s+' | Where-Object { $_ })
+    if ($existingNodeNames -contains $k8sFormattedNodeName) {
         throw "$LogPrefix Precondition not met: node '$k8sFormattedNodeName' is already part of the cluster."
     }
 


### PR DESCRIPTION
Issue : The system package command  .\k2s.exe system package --node-package --os "debian13" --target-dir "C:\var" --name "k8s-packages-debian13.zip" --include-gpu --proxy "http://172.19.1.1:8181" failed to download the nvidia packages due to proxy misconfiguration .

This pr contains code changes to fix the proxy configuration for gpu node package downloads.