### PR TITLE
Stopped unconditionally generating the WSL rootfs during every package build.

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/provisioning.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/baseimage/provisioning.module.psm1
@@ -16,17 +16,17 @@ $kubenodeBaseFileName = 'Kubenode-Base.vhdx'
 $kubeNodeBaseImagePath = "$kubeBinPath\$kubenodeBaseFileName"
 
 $KubemasterVmProvisioningVmName = 'KUBEMASTER_IN_PROVISIONING'
-$RawBaseImageInProvisioningForKubemasterImageName = 'Debian-12-Base-In-Provisioning-For-Kubemaster.vhdx'
+$RawBaseImageInProvisioningForKubemasterImageName = 'Debian-13-Base-In-Provisioning-For-Kubemaster.vhdx'
 $VmProvisioningNatName = 'KubemasterVmProvisioningNat'
 $VmProvisioningSwitchName = 'KubemasterVmProvisioningSwitch'
 
 $KubeworkerVmProvisioningVmName = 'KUBEWORKER_IN_PROVISIONING'
-$RawBaseImageInProvisioningForKubeworkerImageName = 'Debian-12-Base-In-Provisioning-For-Kubeworker.vhdx'
+$RawBaseImageInProvisioningForKubeworkerImageName = 'Debian-13-Base-In-Provisioning-For-Kubeworker.vhdx'
 $KubeworkerVmProvisioningNatName = 'KubeworkerVmProvisioningNat'
 $KubeworkerVmProvisioningSwitchName = 'KubeworkerVmProvisioningSwitch'
 
 $KubenodeVmProvisioningVmName = 'KUBENODE_IN_PROVISIONING'
-$RawBaseImageInProvisioningForKubenodeImageName = 'Debian-12-Base-In-Provisioning-For-Kubenode.vhdx'
+$RawBaseImageInProvisioningForKubenodeImageName = 'Debian-13-Base-In-Provisioning-For-Kubenode.vhdx'
 $KubenodeVmProvisioningNatName = 'KubenodeVmProvisioningNat'
 $KubenodeVmProvisioningSwitchName = 'KubenodeVmProvisioningSwitch'
 
@@ -95,7 +95,7 @@ function New-KubenodeBaseImage {
     $vmParameters.IsoFileName = 'cloud-init-kubenode-provisioning.iso'
     $vmParameters.MemoryStartupBytes = $VMMemoryStartupBytes
     $vmParameters.ProcessorCount = $VMProcessorCount
-    $vmParameters.ProvisionedVhdxFileName = 'Debian-12-Base-Provisioned-For-Kubenode.vhdx'
+    $vmParameters.ProvisionedVhdxFileName = 'Debian-13-Base-Provisioned-For-Kubenode.vhdx'
     $vmParameters.VmName = $KubenodeVmProvisioningVmName
 
     [GuestOsParameters]$guestOsParameters = [GuestOsParameters]::new() 
@@ -589,20 +589,6 @@ function Convert-VhdxToRootfs {
 
     $vmName = $RootfsWslProvisioningVmName
 
-    # The rootfs creation VM must temporarily hold, under /var/tmp/rootfs (disk-backed root fs),
-    # the copied source vhdx, the fully extracted (uncompressed) root filesystem and the resulting
-    # tarball all at once. /tmp is a RAM-backed tmpfs (~half of RAM) and is too small for this.
-    # Provide more disk than the control plane defaults to avoid scp 'write failure'
-    # / 'no space left on device' errors as the produced image grows in size.
-    $sourceVhdxSizeBytes = (Get-Item -Path $SourceVhdxPath).Length
-    $requiredDiskSize = [uint64]$sourceVhdxSizeBytes * 6 + 20GB
-    $rootfsVmDiskSize = [System.Math]::Max([uint64]$VMDiskSize, $requiredDiskSize)
-    $rootfsVmMemory = [System.Math]::Max([long]$VMMemoryStartupBytes, [long]8GB)
-    $sourceVhdxSizeGB = [System.Math]::Round($sourceVhdxSizeBytes / 1GB, 2)
-    $rootfsVmDiskSizeGB = [System.Math]::Round($rootfsVmDiskSize / 1GB, 2)
-    $rootfsVmMemoryGB = [System.Math]::Round($rootfsVmMemory / 1GB, 2)
-    Write-Log "Rootfs creation VM '$vmName': source vhdx ${sourceVhdxSizeGB}GB -> using disk ${rootfsVmDiskSizeGB}GB, memory ${rootfsVmMemoryGB}GB" -Console
-
     $Hook = {
         New-RootfsForWSL -IpAddress $(Get-VmIpForProvisioningKubeNode) -UserName $(Get-DefaultUserNameKubeNode) -UserPwd $(Get-DefaultUserPwdKubeNode) -VhdxFile $SourceVhdxPath -TargetFilePath $TargetRootfsFilePath
     }
@@ -611,8 +597,8 @@ function Convert-VhdxToRootfs {
         VhdxPath=$rootfsCreatorHostVhdxPath
         VmName=$vmName
         Hook = $Hook
-        VMDiskSize = $rootfsVmDiskSize
-        VMMemoryStartupBytes = $rootfsVmMemory
+        VMDiskSize = $VMDiskSize
+        VMMemoryStartupBytes = $VMMemoryStartupBytes
         VMProcessorCount = $VMProcessorCount
     }
     Start-VmBasedOnKubenodeBaseImage @vmBasedOnKubenodeBaseImageStartParams

--- a/lib/scripts/k2s/system/package/New-K2sPackage.Provisioning.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sPackage.Provisioning.ps1
@@ -33,16 +33,6 @@ function New-ProvisionedKubemasterBaseImage($WindowsNodeArtifactsZip, $OutputPat
         Invoke-DeployPuttytoolsArtifacts $windowsNodeArtifactsDirectory
         # Provision linux node artifacts
         Write-Log 'Create and provision the base image' -Console
-        $baseDirectory = $(Split-Path -Path $OutputPath)
-        $rootfsPath = "$baseDirectory\$(Get-ControlPlaneOnWslRootfsFileName)"
-        if (Test-Path -Path $rootfsPath) {
-            Remove-Item -Path $rootfsPath -Force
-            Write-Log "Deleted already existing file for WSL support '$rootfsPath'"
-        }
-        else {
-            Write-Log "File for WSL support '$rootfsPath' does not exist. Nothing to delete."
-        }
-    
         $hostname = Get-ConfigControlPlaneNodeHostname
         $ipAddress = Get-ConfiguredIPControlPlane
         $gatewayIpAddress = Get-ConfiguredKubeSwitchIP
@@ -67,21 +57,6 @@ function New-ProvisionedKubemasterBaseImage($WindowsNodeArtifactsZip, $OutputPat
     
         if (!(Test-Path -Path $OutputPath)) {
             throw "The file '$OutputPath' was not created"
-        }
-    
-
-        $wslRootfsForControlPlaneNodeCreationParams = @{
-            VmImageInputPath     = $OutputPath
-            RootfsFileOutputPath = $rootfsPath
-            Proxy                = $Proxy
-            VMMemoryStartupBytes = $VMMemoryStartupBytes
-            VMProcessorCount     = $VMProcessorCount
-            VMDiskSize           = $VMDiskSize
-        }
-        New-WslRootfsForControlPlaneNode @wslRootfsForControlPlaneNodeCreationParams
-    
-        if (!(Test-Path -Path $rootfsPath)) {
-            throw "The file '$rootfsPath' was not created"
         }
     }
     finally {

--- a/lib/scripts/k2s/system/package/New-K2sPackage.Provisioning.ps1
+++ b/lib/scripts/k2s/system/package/New-K2sPackage.Provisioning.ps1
@@ -33,6 +33,12 @@ function New-ProvisionedKubemasterBaseImage($WindowsNodeArtifactsZip, $OutputPat
         Invoke-DeployPuttytoolsArtifacts $windowsNodeArtifactsDirectory
         # Provision linux node artifacts
         Write-Log 'Create and provision the base image' -Console
+        $baseDirectory = $(Split-Path -Path $OutputPath)
+        $rootfsPath = "$baseDirectory\$(Get-ControlPlaneOnWslRootfsFileName)"
+        if (Test-Path -Path $rootfsPath) {
+            Remove-Item -Path $rootfsPath -Force
+            Write-Log "Deleted already existing file for WSL support '$rootfsPath'"
+        }
         $hostname = Get-ConfigControlPlaneNodeHostname
         $ipAddress = Get-ConfiguredIPControlPlane
         $gatewayIpAddress = Get-ConfiguredKubeSwitchIP


### PR DESCRIPTION
Issue :

The offline packaging pipeline (New-K2sPackage.Provisioning.ps1) was unconditionally generating the WSL rootfs as part of every package build. 

To do that it:
- Spun up a dedicated temporary VM named ROOTFS_FOR_WSL_IN_CREATION.
- Converted the KubeMaster base VHDX into a WSL rootfs (Convert-VhdxToRootfs), tar‑gzipping the filesystem into Kubemaster-Base.rootfs.tar.gz.

This caused two concrete problems:

- Resource failure on smaller hosts. The ROOTFS_FOR_WSL_IN_CREATION VM was sized to need ~8 GB of memory. On machines with ~4 GB free, packaging failed at this step.
- The rootfs is only ever needed for k2s install --wsl. The default Hyper‑V install path never uses it, and the WSL install path regenerates the rootfs on demand anyway (New-WslLinuxVmAsControlPlaneNode rebuilds it if (!(Test-Path $rootfsPath))). So packaging was building an expensive artifact that most users never consume and that is recreated when actually required.
- The logs and provisioning constants still referenced the old Debian 12 filenames even though the default distro had moved to Debian 13, producing misleading output like Debian-12-Base-In-Provisioning-For-Kubemaster.vhdx.

Fix:

- Removed WSL rootfs generation from packaging. 
- Corrected the stale Debian‑12 → Debian‑13 filenames
- also reverted the method content Convert-VhdxToRootfs from the previous version to use the hardware configurations from the command line while using k2s install with --wsl flag.
