### PR TITLE
#2216 fix(build): fall back to unknown git metadata outside a git repo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,24 +86,29 @@ echo "VERSION: $VERSION"
 BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 echo "BUILD_DATE: $BUILD_DATE"
 
-# GIT COMMIT
-GIT_COMMIT="$(git rev-parse HEAD)"
-echo "GIT_COMMIT: $GIT_COMMIT"
+# GIT COMMIT, TREE STATE, AND TAG
+# Falls back to "unknown" (instead of aborting the build under `set -e`)
+# when the script runs outside a git working tree, e.g. from files copied
+# without .git.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    GIT_COMMIT="$(git rev-parse HEAD)"
 
-# GIT TREE STATE AND TAG
-GIT_TAG=""
-GIT_TREE_STATE="clean"
-if [[ -n "$(git status --porcelain)" ]]; then
-    GIT_TREE_STATE="dirty"
-else
-    # Clean tree: check for an exact tag to declare an official release.
-    if GIT_TAG="$(git describe --exact-match --tags HEAD 2>/dev/null)"; then
-        echo "GIT_TAG: $GIT_TAG"
+    GIT_TAG=""
+    GIT_TREE_STATE="clean"
+
+    if [[ -n "$(git status --porcelain)" ]]; then
+        GIT_TREE_STATE="dirty"
     else
-        GIT_TAG=""
-        echo "No tag found for the git commit"
+        GIT_TAG="$(git describe --exact-match --tags HEAD 2>/dev/null || true)"
     fi
+else
+    echo "No git repository found."
+
+    GIT_COMMIT="unknown"
+    GIT_TAG=""
+    GIT_TREE_STATE="unknown"
 fi
+echo "GIT_COMMIT: $GIT_COMMIT"
 echo "GIT_TREE_STATE: $GIT_TREE_STATE"
 
 VERSION_PKG="github.com/siemens-healthineers/k2s/internal/version"


### PR DESCRIPTION
Refs #2216

### Motivation

`build.sh` (added in #2216 / PR #2790) called `git rev-parse HEAD`
unconditionally. When run from a directory without a `.git` folder (e.g.
files copied to a build/test VM without a full clone), `set -euo pipefail`
caused the entire build to abort immediately with
`fatal: not a git repository`, before any binaries were produced.

### Modifications

- `build.sh` — wrapped git commit/tag/tree-state detection in a
  `git rev-parse --is-inside-work-tree` guard. When true, behavior is
  unchanged (same commit/tag/tree-state logic). When false, falls back to
  `unknown`/empty version metadata (matching `internal/version`'s own
  defaults) and prints `No git repository found.` instead of aborting.

### Verification

- Manual: ran `./build.sh` on a Linux VM with no `.git` directory present.
  Confirmed it now prints `No git repository found.`, sets
  `GIT_COMMIT=unknown` / `GIT_TREE_STATE=unknown`, and completes the build,
  producing all four executables (`k2s.linux`, `cloudinitisobuilder`,
  `httpproxy`, `yaml2json`) against a vendored module cache.

### Acceptance Criteria

- [x] Script no longer aborts when run outside a git working tree — verified
  by VM run (fallback message printed, build completed).
- [x] Falls back to `unknown`/empty version metadata instead of failing —
  verified by VM run output.
- [x] Behavior unchanged when run inside a git repo — verified by code
  review (original logic preserved, only wrapped in a guard).