### PR TITLE
Fix test addon rollout argocd

### DIFF
--- a/addons/rollout/argocd/Enable.ps1
+++ b/addons/rollout/argocd/Enable.ps1
@@ -107,7 +107,7 @@ $rolloutConfig = Get-RolloutConfig
 
 Write-Log 'Waiting for pods being ready...' -Console
 
-$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'deployments', '-n', $rolloutNamespace, '--timeout=300s')
+$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'deployments', '-n', $rolloutNamespace, '--timeout=600s')
 Write-Log $kubectlCmd.Output
 if (!$kubectlCmd.Success) {
     $errMsg = 'rollout addon could not be deployed successfully!'
@@ -121,7 +121,7 @@ if (!$kubectlCmd.Success) {
     exit 1
 }
 
-$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'statefulsets', '-n', $rolloutNamespace, '--timeout=300s')
+$kubectlCmd = (Invoke-Kubectl -Params 'rollout', 'status', 'statefulsets', '-n', $rolloutNamespace, '--timeout=600s')
 Write-Log $kubectlCmd.Output
 if (!$kubectlCmd.Success) {
     $errMsg = 'rollout addon (ArgoCD application controller) could not be deployed successfully'

--- a/addons/rollout/argocd/Enable.ps1
+++ b/addons/rollout/argocd/Enable.ps1
@@ -101,7 +101,9 @@ Write-Log 'Creating rollout namespace'
 
 Write-Log 'Installing rollout addon' -Console
 $rolloutConfig = Get-RolloutConfig
-(Invoke-Kubectl -Params 'apply' , '-n', $rolloutNamespace, '-k', $rolloutConfig).Output | Write-Log
+# Use --server-side to avoid the 256KB annotation size limit that client-side
+# apply hits on large CRDs (e.g. applicationsets.argoproj.io).
+(Invoke-Kubectl -Params 'apply', '--server-side', '--force-conflicts', '-n', $rolloutNamespace, '-k', $rolloutConfig).Output | Write-Log
 
 Write-Log 'Waiting for pods being ready...' -Console
 

--- a/k2s/test/e2e/addons/rollout/argocd/rollout-argocd_test.go
+++ b/k2s/test/e2e/addons/rollout/argocd/rollout-argocd_test.go
@@ -25,6 +25,11 @@ import (
 
 const testClusterTimeout = time.Minute * 20
 
+const (
+	statusCheckRetryTimeout = 3 * time.Minute
+	statusCheckRetryPolling = 10 * time.Second
+)
+
 var (
 	suite                 *framework.K2sTestSuite
 	portForwardingSession *gexec.Session
@@ -344,9 +349,9 @@ func expectListToDisplayImplementation(ctx context.Context) {
 }
 
 func expectStatusToBePrinted(ctx context.Context) {
-	output := suite.K2sCli().MustExec(ctx, "addons", "status", "rollout", "argocd")
-
-	Expect(output).To(SatisfyAll(
+	Eventually(func() string {
+		return suite.K2sCli().MustExec(ctx, "addons", "status", "rollout", "argocd")
+	}).WithTimeout(statusCheckRetryTimeout).WithPolling(statusCheckRetryPolling).Should(SatisfyAll(
 		MatchRegexp("ADDON STATUS"),
 		MatchRegexp(`Implementation .+argocd.+ of Addon .+rollout.+ is .+enabled.+`),
 		MatchRegexp("ArgoCD Application Set Controller is working"),
@@ -358,53 +363,55 @@ func expectStatusToBePrinted(ctx context.Context) {
 		MatchRegexp("ArgoCD Application Server is working"),
 	))
 
-	output = suite.K2sCli().MustExec(ctx, "addons", "status", "rollout", "argocd", "-o", "json")
+	Eventually(func(g Gomega) {
+		output := suite.K2sCli().MustExec(ctx, "addons", "status", "rollout", "argocd", "-o", "json")
 
-	var status status.AddonPrintStatus
+		var status status.AddonPrintStatus
 
-	Expect(json.Unmarshal([]byte(output), &status)).To(Succeed())
+		g.Expect(json.Unmarshal([]byte(output), &status)).To(Succeed())
 
-	Expect(status.Name).To(Equal("rollout"))
-	Expect(status.Implementation).To(Equal("argocd"))
-	Expect(status.Error).To(BeNil())
-	Expect(status.Enabled).NotTo(BeNil())
-	Expect(*status.Enabled).To(BeTrue())
-	Expect(status.Props).NotTo(BeNil())
-	Expect(status.Props).To(ContainElements(
-		SatisfyAll(
-			HaveField("Name", "IsArgoCDApplicationsetControllerRunning"),
-			HaveField("Value", true),
-			HaveField("Okay", gstruct.PointTo(BeTrue())),
-			HaveField("Message", gstruct.PointTo(ContainSubstring("ArgoCD Application Set Controller is working")))),
-		SatisfyAll(
-			HaveField("Name", "IsArgoCDDexServerRunning"),
-			HaveField("Value", true),
-			HaveField("Okay", gstruct.PointTo(BeTrue())),
-			HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Dex Server is working")))),
-		SatisfyAll(
-			HaveField("Name", "IsArgoCDNotificationControllerRunning"),
-			HaveField("Value", true),
-			HaveField("Okay", gstruct.PointTo(BeTrue())),
-			HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Notification Controller is working")))),
-		SatisfyAll(
-			HaveField("Name", "IsArgoCDRedisRunning"),
-			HaveField("Value", true),
-			HaveField("Okay", gstruct.PointTo(BeTrue())),
-			HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Redis DB is working")))),
-		SatisfyAll(
-			HaveField("Name", "IsArgoCDRepoServerRunning"),
-			HaveField("Value", true),
-			HaveField("Okay", gstruct.PointTo(BeTrue())),
-			HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Repo Server is working")))),
-		SatisfyAll(
-			HaveField("Name", "IsArgoCDServerRunning"),
-			HaveField("Value", true),
-			HaveField("Okay", gstruct.PointTo(BeTrue())),
-			HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Server is working")))),
-		SatisfyAll(
-			HaveField("Name", "AreStatefulsetsRunning"),
-			HaveField("Value", true),
-			HaveField("Okay", gstruct.PointTo(BeTrue())),
-			HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Application Server is working")))),
-	))
+		g.Expect(status.Name).To(Equal("rollout"))
+		g.Expect(status.Implementation).To(Equal("argocd"))
+		g.Expect(status.Error).To(BeNil())
+		g.Expect(status.Enabled).NotTo(BeNil())
+		g.Expect(*status.Enabled).To(BeTrue())
+		g.Expect(status.Props).NotTo(BeNil())
+		g.Expect(status.Props).To(ContainElements(
+			SatisfyAll(
+				HaveField("Name", "IsArgoCDApplicationsetControllerRunning"),
+				HaveField("Value", true),
+				HaveField("Okay", gstruct.PointTo(BeTrue())),
+				HaveField("Message", gstruct.PointTo(ContainSubstring("ArgoCD Application Set Controller is working")))),
+			SatisfyAll(
+				HaveField("Name", "IsArgoCDDexServerRunning"),
+				HaveField("Value", true),
+				HaveField("Okay", gstruct.PointTo(BeTrue())),
+				HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Dex Server is working")))),
+			SatisfyAll(
+				HaveField("Name", "IsArgoCDNotificationControllerRunning"),
+				HaveField("Value", true),
+				HaveField("Okay", gstruct.PointTo(BeTrue())),
+				HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Notification Controller is working")))),
+			SatisfyAll(
+				HaveField("Name", "IsArgoCDRedisRunning"),
+				HaveField("Value", true),
+				HaveField("Okay", gstruct.PointTo(BeTrue())),
+				HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Redis DB is working")))),
+			SatisfyAll(
+				HaveField("Name", "IsArgoCDRepoServerRunning"),
+				HaveField("Value", true),
+				HaveField("Okay", gstruct.PointTo(BeTrue())),
+				HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Repo Server is working")))),
+			SatisfyAll(
+				HaveField("Name", "IsArgoCDServerRunning"),
+				HaveField("Value", true),
+				HaveField("Okay", gstruct.PointTo(BeTrue())),
+				HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Server is working")))),
+			SatisfyAll(
+				HaveField("Name", "AreStatefulsetsRunning"),
+				HaveField("Value", true),
+				HaveField("Okay", gstruct.PointTo(BeTrue())),
+				HaveField("Message", gstruct.PointTo(MatchRegexp("ArgoCD Application Server is working")))),
+		))
+	}).WithTimeout(statusCheckRetryTimeout).WithPolling(statusCheckRetryPolling).Should(Succeed())
 }

--- a/lib/scripts/k2s/system/startup/Start-System.ps1
+++ b/lib/scripts/k2s/system/startup/Start-System.ps1
@@ -364,7 +364,7 @@ function Start-K8sNetworkingServices {
     Write-Log "[$logUseCase] Waiting for API server before restarting system DaemonSets (kubeconfig: $kubeConfigPath)..."
     try {
         $apiReady = $false
-        for ($attempt = 1; $attempt -le 15; $attempt++) {
+        for ($attempt = 1; $attempt -le 20; $attempt++) {
             $ErrorActionPreference = 'Continue'
             $waitResult = &"$kubeBinPathTools\kubectl.exe" --kubeconfig="$kubeConfigPath" wait --timeout=30s --for=condition=Ready -n kube-system "pod/kube-apiserver-$($controlPlaneHostname.ToLower())" 2>&1
             $ErrorActionPreference = 'Stop'
@@ -372,17 +372,17 @@ function Start-K8sNetworkingServices {
                 $apiReady = $true
                 break
             }
-            Write-Log "[$logUseCase] API server not ready yet (attempt $attempt/15): $waitResult"
+            Write-Log "[$logUseCase] API server not ready yet (attempt $attempt/20): $waitResult"
             Start-Sleep -Seconds 2
         }
         if ($apiReady) {
             Write-Log "[$logUseCase] Restarting Linux-side system DaemonSets to refresh service account tokens..."
             (Invoke-KubectlWithKubeConfig -KubeConfigPath $kubeConfigPath -Params @('rollout', 'restart', 'daemonset/kube-proxy', '-n', 'kube-system')).Output | Write-Log
-            Restart-FlannelDaemonSetWithWindowsRouteRepair -KubeConfigPath $kubeConfigPath -MaxAttempts 3
+            Restart-FlannelDaemonSetWithWindowsRouteRepair -KubeConfigPath $kubeConfigPath -MaxAttempts 6
             (Invoke-KubectlWithKubeConfig -KubeConfigPath $kubeConfigPath -Params @('rollout', 'restart', 'deployment/coredns', '-n', 'kube-system')).Output | Write-Log
             Write-Log "[$logUseCase] Linux-side system DaemonSet restart completed"
         } else {
-            Write-Log "[$logUseCase] WARNING: API server not ready after 15 attempts, skipping DaemonSet restart"
+            Write-Log "[$logUseCase] WARNING: API server not ready after 20 attempts, skipping DaemonSet restart"
         }
     } catch {
         Write-Log "[$logUseCase] WARNING: Failed to restart Linux-side DaemonSets: $_"


### PR DESCRIPTION
Fixes for test addon-rollout-argocd
increase API server readiness attempts and adjust related logging
implement retries for ArgoCD status checks in tests
use server-side apply to handle large CRDs in rollout addon installation
increase timeout for rollout status checks in ArgoCD addon installation