### PR TITLE
fix: skip disk-check gaurd when online installation is not triggered

### DIFF
--- a/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.psm1
@@ -748,7 +748,8 @@ function Assert-ControlPlaneArtifactDiskSizeCompatibility {
 
     $controlPlaneBaseImagePath = Get-ControlPlaneVMBaseImagePath
     if (!(Test-Path -Path $controlPlaneBaseImagePath)) {
-        throw "[PREREQ-FAILED] Precheck failed: expected packaged control-plane artifact is missing at '$controlPlaneBaseImagePath'. Installation cannot validate disk-size compatibility safely. Restore a complete package (including base VHDX) or run an explicit online installation mode."
+        Write-Log "[Precheck] Skip package disk-size guard because packaged control-plane artifact is missing at '$controlPlaneBaseImagePath'. This is allowed for online installation when the base VHDX is not present in the local bin folder."
+        return
     }
 
     try {

--- a/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.unit.tests.ps1
+++ b/lib/modules/k2s/k2s.node.module/linuxnode/vm/vm.module.unit.tests.ps1
@@ -264,12 +264,15 @@ Describe 'Control-plane artifact disk-size precheck' -Tag 'unit', 'ci', 'vm' {
             }
         }
 
-        It 'fails when packaged control-plane artifact is missing' {
+        It 'skips package guard when packaged control-plane artifact is missing' {
             InModuleScope $moduleName {
                 Mock Get-ControlPlaneVMBaseImagePath { 'C:\pkg\Kubemaster-Base.vhdx' }
                 Mock Test-Path { $false }
 
-                { Assert-ControlPlaneArtifactDiskSizeCompatibility -MasterDiskSize 60GB } | Should -Throw '*Precheck failed*missing*'
+                { Assert-ControlPlaneArtifactDiskSizeCompatibility -MasterDiskSize 60GB } | Should -Not -Throw
+
+                Should -Invoke Get-ControlPlaneVMBaseImagePath -Times 1 -Exactly
+                Should -Invoke Test-Path -Times 1 -Exactly
             }
         }
 


### PR DESCRIPTION
when the k2s artifacts are not present in the bin, then we implemented a gaurd to throw exception when the kubemaster vhdx is not found. This is a scenario of online installation which is not forced by the user. 

In this PR, we skip the check if the vhdx is not found to be present.