### PR TITLE
#2846 fix(addons): wait for CA rotation before import

### DIFF
--- a/addons/addons.module.psm1
+++ b/addons/addons.module.psm1
@@ -1842,8 +1842,13 @@ function Initialize-CACertificateIssuer {
         throw "CA root certificate 'ca-issuer-root-secret' not found.`nInstallation of 'cert-manager' failed."
     }
 
+    # Capture the current CA content before renewal to detect rotation.
+    $previousCaHash = Get-CARootCertificateHash
+
     # Write-Log 'Renewing old Certificates using the new CA Issuer' -Console
     Update-CertificateResources
+
+    Wait-ForCARootCertificateRotation -PreviousHash $previousCaHash
 }
 
 <#
@@ -1894,6 +1899,39 @@ function Wait-ForCARootCertificate(
     $cmEvents = (Invoke-Kubectl -Params '-n', 'cert-manager', 'get', 'events', '--sort-by=.lastTimestamp').Output
     Write-Log "[CertManager] cert-manager events: $cmEvents" -Console
 
+    return $false
+}
+
+# Returns the current CA content, or an empty string when it is unavailable.
+function Get-CARootCertificateHash {
+    $out = (Invoke-Kubectl -Params '-n', 'cert-manager', 'get', 'secrets', 'ca-issuer-root-secret', '-o', 'jsonpath', '--template', '{.data.ca\.crt}').Output
+    if ([string]::IsNullOrWhiteSpace($out)) {
+        return ''
+    }
+    return $out
+}
+
+# Waits for CA content to change after renewal, without blocking fresh installs.
+function Wait-ForCARootCertificateRotation(
+    [string]$PreviousHash,
+    [int]$SleepDurationInSeconds = 5,
+    [int]$NumberOfRetries = 12) {
+    if ([string]::IsNullOrWhiteSpace($PreviousHash)) {
+        Write-Log '[CertManager] No previous CA root certificate content captured; skipping rotation wait.'
+        return $true
+    }
+
+    for ($i = 1; $i -le $NumberOfRetries; $i++) {
+        $currentHash = Get-CARootCertificateHash
+        if (-not [string]::IsNullOrWhiteSpace($currentHash) -and $currentHash -ne $PreviousHash) {
+            Write-Log '[CertManager] CA root certificate rotation detected; proceeding with import.'
+            return $true
+        }
+        Write-Log "Retry {$i}: CA root certificate not yet rotated. Will retry after $SleepDurationInSeconds Seconds" -Console
+        Start-Sleep -Seconds $SleepDurationInSeconds
+    }
+
+    Write-Log '[CertManager] CA root certificate rotation was not detected within the retry budget. Proceeding with import anyway; the imported CA may be stale until the next renewal cycle completes.' -Console
     return $false
 }
 

--- a/addons/addons.module.psm1
+++ b/addons/addons.module.psm1
@@ -1927,8 +1927,10 @@ function Wait-ForCARootCertificateRotation(
             Write-Log '[CertManager] CA root certificate rotation detected; proceeding with import.'
             return $true
         }
-        Write-Log "Retry {$i}: CA root certificate not yet rotated. Will retry after $SleepDurationInSeconds Seconds" -Console
-        Start-Sleep -Seconds $SleepDurationInSeconds
+        if ($i -lt $NumberOfRetries) {
+            Write-Log "Retry {$i}: CA root certificate not yet rotated. Will retry after $SleepDurationInSeconds Seconds" -Console
+            Start-Sleep -Seconds $SleepDurationInSeconds
+        }
     }
 
     Write-Log '[CertManager] CA root certificate rotation was not detected within the retry budget. Proceeding with import anyway; the imported CA may be stale until the next renewal cycle completes.' -Console

--- a/addons/addons.module.unit.tests.ps1
+++ b/addons/addons.module.unit.tests.ps1
@@ -1484,6 +1484,7 @@ Describe 'Wait-ForCARootCertificateRotation' -Tag 'unit', 'ci', 'addon' {
 
             $result | Should -BeFalse
             Should -Invoke Get-CARootCertificateHash -Times 3 -Scope It
+            Should -Invoke Start-Sleep -Times 2 -Scope It
         }
     }
 }

--- a/addons/addons.module.unit.tests.ps1
+++ b/addons/addons.module.unit.tests.ps1
@@ -1378,6 +1378,8 @@ Describe 'Initialize-CACertificateIssuer' -Tag 'unit', 'ci', 'addon' {
         Mock -ModuleName $moduleName Wait-ForCARootCertificate { return $true }
         Mock -ModuleName $moduleName Update-CertificateResources { }
         Mock -ModuleName $moduleName Clear-KubectlDiscoveryCache { }
+        Mock -ModuleName $moduleName Get-CARootCertificateHash { return 'old-hash' }
+        Mock -ModuleName $moduleName Wait-ForCARootCertificateRotation { return $true }
     }
 
     It 'clears cache and applies issuer manifest and waits for root cert' {
@@ -1392,6 +1394,18 @@ Describe 'Initialize-CACertificateIssuer' -Tag 'unit', 'ci', 'addon' {
         }
     }
 
+    It 'captures the CA hash before renewal and waits for rotation using it afterwards' {
+        InModuleScope -ModuleName $moduleName {
+            Initialize-CACertificateIssuer
+
+            Should -Invoke Get-CARootCertificateHash -Times 1 -Scope It
+            Should -Invoke Update-CertificateResources -Times 1 -Scope It
+            Should -Invoke Wait-ForCARootCertificateRotation -Times 1 -Scope It -ParameterFilter {
+                $PreviousHash -eq 'old-hash'
+            }
+        }
+    }
+
     Context 'CA root certificate is never created' {
         BeforeAll {
             Mock -ModuleName $moduleName Wait-ForCARootCertificate { return $false }
@@ -1401,6 +1415,75 @@ Describe 'Initialize-CACertificateIssuer' -Tag 'unit', 'ci', 'addon' {
             InModuleScope -ModuleName $moduleName {
                 { Initialize-CACertificateIssuer } | Should -Throw
             }
+        }
+    }
+}
+
+Describe 'Get-CARootCertificateHash' -Tag 'unit', 'ci', 'addon' {
+    It 'returns the secret content when readable' {
+        InModuleScope -ModuleName $moduleName {
+            Mock Invoke-Kubectl { return [pscustomobject]@{ Output = 'BASE64DATA' } }
+
+            $result = Get-CARootCertificateHash
+
+            $result | Should -Be 'BASE64DATA'
+        }
+    }
+
+    It 'returns an empty string when the secret content cannot be read' {
+        InModuleScope -ModuleName $moduleName {
+            Mock Invoke-Kubectl { return [pscustomobject]@{ Output = '' } }
+
+            $result = Get-CARootCertificateHash
+
+            $result | Should -Be ''
+        }
+    }
+}
+
+Describe 'Wait-ForCARootCertificateRotation' -Tag 'unit', 'ci', 'addon' {
+    BeforeAll {
+        Mock -ModuleName $moduleName Write-Log { }
+        Mock -ModuleName $moduleName Start-Sleep { }
+    }
+
+    It 'returns true immediately when PreviousHash is empty (fresh install, nothing to wait for)' {
+        InModuleScope -ModuleName $moduleName {
+            Mock Get-CARootCertificateHash { return 'anything' }
+
+            $result = Wait-ForCARootCertificateRotation -PreviousHash '' -SleepDurationInSeconds 0 -NumberOfRetries 3
+
+            $result | Should -BeTrue
+            Should -Invoke Get-CARootCertificateHash -Times 0 -Scope It
+        }
+    }
+
+    It 'returns true as soon as the content differs from PreviousHash' {
+        InModuleScope -ModuleName $moduleName {
+            $script:callCount = 0
+            Mock Get-CARootCertificateHash {
+                $script:callCount++
+                if ($script:callCount -lt 2) {
+                    return 'old-hash'
+                }
+                return 'new-hash'
+            }
+
+            $result = Wait-ForCARootCertificateRotation -PreviousHash 'old-hash' -SleepDurationInSeconds 0 -NumberOfRetries 5
+
+            $result | Should -BeTrue
+            Should -Invoke Get-CARootCertificateHash -Times 2 -Scope It
+        }
+    }
+
+    It 'returns false without throwing when rotation is never observed within retries' {
+        InModuleScope -ModuleName $moduleName {
+            Mock Get-CARootCertificateHash { return 'old-hash' }
+
+            $result = Wait-ForCARootCertificateRotation -PreviousHash 'old-hash' -SleepDurationInSeconds 0 -NumberOfRetries 3
+
+            $result | Should -BeFalse
+            Should -Invoke Get-CARootCertificateHash -Times 3 -Scope It
         }
     }
 }


### PR DESCRIPTION
Fixes #2846

### Motivation

CA rotation updates the cert-manager CA secret asynchronously. Importing the Windows CA immediately after renewal could therefore import stale certificate content.

### Modifications

- `addons/addons.module.psm1` - Captures the current CA secret content before renewal and waits for the content to change before importing it. Fresh-install behavior is preserved when no previous CA content exists.
- `addons/addons.module.unit.tests.ps1` - Adds coverage for CA capture order, readable and unreadable secret content, fresh installs, observed rotation, and retry exhaustion.

### Verification

- Unit tests added/updated: `addons/addons.module.unit.tests.ps1`
- Manual testing: Live CA rotation and Windows import verification passed; certificate values were withheld.
- Elevated Pester result, user-reported: 140 passed, 0 failed, 0 skipped, 0 inconclusive, 0 not run.
- e2e tests passed

### Acceptance Criteria

- [x] AC1: End-to-end CA rotation and Windows import succeeds - verified by live rotation/import testing with certificate values withheld.
- [x] AC2: The import path waits for actual CA secret content rotation rather than secret existence - verified by poll-until-changed tests and live validation.
- [x] AC3: Unit tests cover the poll-until-changed behavior - user-reported elevated Pester result: 140 passed, 0 failed.
- [x] AC4: Fresh-install behavior remains unchanged when no prior CA exists - covered by the existing tests and verified behavior.