### PR TITLE
#2221 [Reverted Setup Linux] System backup on linux hosts

### DIFF
--- a/cmd/k2s/cmd/system/backup/backup.go
+++ b/cmd/k2s/cmd/system/backup/backup.go
@@ -4,16 +4,15 @@
 package backup
 
 import (
-	"strconv"
 	"fmt"
-	"time"
+	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 
 	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/common"
-	"github.com/siemens-healthineers/k2s/cmd/k2s/utils"
 	"github.com/siemens-healthineers/k2s/internal/provider"
 )
 
@@ -21,9 +20,7 @@ const (
 	backupFileFlag = "file"
 	skipImagesFlag = "skip-images"
 	skipPVsFlag    = "skip-pvs"
-	defaultBackupDir = "C:\\Temp\\k2s\\backups"
 )
-
 
 var SystemBackupCmd = &cobra.Command{
 	Use:   "backup",
@@ -33,24 +30,37 @@ var SystemBackupCmd = &cobra.Command{
 
 func init() {
 	SystemBackupCmd.Flags().SortFlags = false
-	SystemBackupCmd.Flags().StringP(backupFileFlag, "f", "", "Backup file to create (zip). If omitted, a default file in C://Temp/k2s/backups is generated",)
-	SystemBackupCmd.Flags().String(common.AdditionalHooksDirFlagName, "", common.AdditionalHooksDirFlagUsage,)
-	SystemBackupCmd.Flags().Bool(skipImagesFlag, false, "Skip backing up container images",)
-	SystemBackupCmd.Flags().Bool(skipPVsFlag, false, "Skip backing up persistent volumes",)
+	SystemBackupCmd.Flags().StringP(backupFileFlag, "f", "", "Backup file to create (.zip). If omitted, a default file in temp directory is generated")
+	SystemBackupCmd.Flags().String(common.AdditionalHooksDirFlagName, "", common.AdditionalHooksDirFlagUsage)
+	SystemBackupCmd.Flags().Bool(skipImagesFlag, false, "Skip backing up container images")
+	SystemBackupCmd.Flags().Bool(skipPVsFlag, false, "Skip backing up persistent volumes")
 }
 
 func runSystemBackup(cmd *cobra.Command, args []string) error {
 	cmdSession := common.StartCmdSession(cmd.CommandPath())
 	pterm.Println("📦 Creating K2s system backup ...")
 
-	out, _ := strconv.ParseBool(cmd.Flags().Lookup(common.OutputFlagName).Value.String())
+	out, err := cmd.Flags().GetBool(common.OutputFlagName)
+	if err != nil {
+		return err
+	}
 
 	backupFile := resolveBackupFileName(cmd)
 
-	additionalHooksDir := cmd.Flags().Lookup(common.AdditionalHooksDirFlagName).Value.String()
+	additionalHooksDir, err := cmd.Flags().GetString(common.AdditionalHooksDirFlagName)
+	if err != nil {
+		return err
+	}
 
-	skipImages, _ := strconv.ParseBool(cmd.Flags().Lookup(skipImagesFlag).Value.String())
-	skipPVs, _ := strconv.ParseBool(cmd.Flags().Lookup(skipPVsFlag).Value.String())
+	skipImages, err := cmd.Flags().GetBool(skipImagesFlag)
+	if err != nil {
+		return err
+	}
+
+	skipPVs, err := cmd.Flags().GetBool(skipPVsFlag)
+	if err != nil {
+		return err
+	}
 
 	context := cmd.Context().Value(common.ContextKeyCmdContext).(*common.CmdContext)
 
@@ -68,48 +78,13 @@ func runSystemBackup(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func createSystemBackupPsCommand(cmd *cobra.Command) string {
-	psCmd := utils.FormatScriptFilePath(
-		utils.InstallDir() +
-			"\\lib\\scripts\\windows\\host\\system\\backup\\Start-SystemBackup.ps1",
-	)
-
-	out, _ := strconv.ParseBool(
-		cmd.Flags().Lookup(common.OutputFlagName).Value.String(),
-	)
-	if out {
-		psCmd += " -ShowLogs"
-	}
-
-	backupFile := resolveBackupFileName(cmd)
-	psCmd += " -BackupFile " + utils.EscapeWithSingleQuotes(backupFile)
-
-	additionalHooksDir := cmd.Flags().Lookup(common.AdditionalHooksDirFlagName).Value.String()
-	if additionalHooksDir != "" {
-		psCmd += " -AdditionalHooksDir " + utils.EscapeWithSingleQuotes(additionalHooksDir)
-	}
-
-	// Pass skip flags to PowerShell if set
-	skipImages, _ := strconv.ParseBool(cmd.Flags().Lookup(skipImagesFlag).Value.String())
-	if skipImages {
-		psCmd += " -SkipImages"
-	}
-
-	skipPVs, _ := strconv.ParseBool(cmd.Flags().Lookup(skipPVsFlag).Value.String())
-	if skipPVs {
-		psCmd += " -SkipPVs"
-	}
-
-	return psCmd
-}
-
 func resolveBackupFileName(cmd *cobra.Command) string {
-	file := cmd.Flags().Lookup(backupFileFlag).Value.String()
-	if file != "" {
+	file, err := cmd.Flags().GetString(backupFileFlag)
+	if err == nil && file != "" {
 		return file
 	}
 
 	timestamp := time.Now().Format("2006-01-02_15-04-05")
 	filename := fmt.Sprintf("k2s-backup-file-%s.zip", timestamp)
-	return filepath.Join(defaultBackupDir, filename)
+	return filepath.Join(os.TempDir(), "k2s", "backups", filename)
 }

--- a/cmd/k2s/cmd/system/backup/backup_test.go
+++ b/cmd/k2s/cmd/system/backup/backup_test.go
@@ -4,14 +4,74 @@
 package backup
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/siemens-healthineers/k2s/cmd/k2s/cmd/common"
-	"github.com/siemens-healthineers/k2s/cmd/k2s/utils"
+	"github.com/siemens-healthineers/k2s/internal/provider"
+	"github.com/stretchr/testify/mock"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+type mockSystemProvider struct {
+	mock.Mock
+}
+
+func (m *mockSystemProvider) Dump(config provider.SystemDumpConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *mockSystemProvider) Upgrade(config provider.SystemUpgradeConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *mockSystemProvider) Package(config provider.SystemPackageConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *mockSystemProvider) Reset(config provider.SystemResetConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *mockSystemProvider) ResetNetwork(config provider.SystemResetNetworkConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *mockSystemProvider) Compact(config provider.SystemCompactConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *mockSystemProvider) Backup(config provider.SystemBackupConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *mockSystemProvider) Restore(config provider.SystemRestoreConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *mockSystemProvider) CertificateRenew(config provider.SystemCertRenewConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
+
+func (m *mockSystemProvider) CertificateAutoRotation(config provider.SystemCertAutoRotationConfig) error {
+	args := m.Called(config)
+	return args.Error(0)
+}
 
 func TestBackup(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -27,73 +87,110 @@ var _ = BeforeSuite(func() {
 	)
 })
 
-// Reset flags helper (same pattern as upgrade)
 func resetBackupFlags() {
 	flags := SystemBackupCmd.Flags()
 	flags.Set(common.OutputFlagName, "false")
 	flags.Set(backupFileFlag, "")
 	flags.Set(common.AdditionalHooksDirFlagName, "")
+	flags.Set(skipImagesFlag, "false")
+	flags.Set(skipPVsFlag, "false")
 }
 
 var _ = Describe("backup", func() {
+	BeforeEach(func() {
+		resetBackupFlags()
+	})
 
-	Describe("createSystemBackupPsCommand", func() {
+	Describe("resolveBackupFileName", func() {
+		When("backup file flag is set", func() {
+			It("returns the specified backup file path", func() {
+				testFile := filepath.Join("test", "dir", "backup.zip")
+				SystemBackupCmd.Flags().Set(backupFileFlag, testFile)
 
-		When("only mandatory flags are set", func() {
-			It("creates minimal backup command", func() {
-				const staticPart = `\lib\scripts\windows\host\system\backup\Start-SystemBackup.ps1`
-				const args = ` -BackupFile 'C:\temp\backup.zip'`
+				actual := resolveBackupFileName(SystemBackupCmd)
 
-				expected := utils.FormatScriptFilePath(
-					utils.InstallDir()+staticPart,
-				) + args
-
-				resetBackupFlags()
-				SystemBackupCmd.Flags().Set(backupFileFlag, `C:\temp\backup.zip`)
-
-				actual := createSystemBackupPsCommand(SystemBackupCmd)
-
-				Expect(actual).To(Equal(expected))
+				Expect(actual).To(Equal(testFile))
 			})
 		})
 
-		When("show logs flag is enabled", func() {
-			It("adds -ShowLogs to command", func() {
-				const staticPart = `\lib\scripts\windows\host\system\backup\Start-SystemBackup.ps1`
-				const args = ` -ShowLogs -BackupFile 'C:\temp\backup.zip'`
+		When("backup file flag is omitted", func() {
+			It("returns a timestamped default backup file in temp directory", func() {
+				expectedDir := filepath.Join(os.TempDir(), "k2s", "backups")
 
-				expected := utils.FormatScriptFilePath(
-					utils.InstallDir()+staticPart,
-				) + args
+				actual := resolveBackupFileName(SystemBackupCmd)
 
-				resetBackupFlags()
-				flags := SystemBackupCmd.Flags()
-				flags.Set(common.OutputFlagName, "true")
-				flags.Set(backupFileFlag, `C:\temp\backup.zip`)
+				Expect(filepath.Dir(actual)).To(Equal(expectedDir))
+				Expect(filepath.Base(actual)).To(HavePrefix("k2s-backup-file-"))
+				Expect(filepath.Base(actual)).To(HaveSuffix(".zip"))
+			})
+		})
+	})
 
-				actual := createSystemBackupPsCommand(SystemBackupCmd)
+	Describe("runSystemBackup", func() {
+		var mockSys *mockSystemProvider
 
-				Expect(actual).To(Equal(expected))
+		BeforeEach(func() {
+			mockSys = &mockSystemProvider{}
+			cmdContext := common.NewCmdContext(nil, nil, &provider.Registry{System: mockSys})
+			ctx := context.WithValue(context.TODO(), common.ContextKeyCmdContext, cmdContext)
+			SystemBackupCmd.SetContext(ctx)
+		})
+
+		When("default flags are used", func() {
+			It("calls provider Backup with default config", func() {
+				mockSys.On("Backup", mock.MatchedBy(func(cfg provider.SystemBackupConfig) bool {
+					expectedDir := filepath.Join(os.TempDir(), "k2s", "backups")
+					return filepath.Dir(cfg.BackupFile) == expectedDir &&
+						strings.HasPrefix(filepath.Base(cfg.BackupFile), "k2s-backup-file-") &&
+						strings.HasSuffix(cfg.BackupFile, ".zip") &&
+						cfg.AdditionalHooksDir == "" &&
+						!cfg.SkipImages &&
+						!cfg.SkipPVs &&
+						!cfg.ShowOutput
+				})).Return(nil).Once()
+
+				err := runSystemBackup(SystemBackupCmd, nil)
+
+				Expect(err).ToNot(HaveOccurred())
+				mockSys.AssertExpectations(GinkgoT())
 			})
 		})
 
-		When("additional hooks directory is provided", func() {
-			It("adds -AdditionalHooksDir to command", func() {
-				const staticPart = `\lib\scripts\windows\host\system\backup\Start-SystemBackup.ps1`
-				const args = ` -BackupFile 'C:\temp\backup.zip' -AdditionalHooksDir 'hooksDir'`
+		When("custom flags are provided", func() {
+			It("passes all flag values to provider Backup", func() {
+				customFile := filepath.Join("custom", "path", "my-backup.zip")
+				SystemBackupCmd.Flags().Set(backupFileFlag, customFile)
+				SystemBackupCmd.Flags().Set(common.AdditionalHooksDirFlagName, "/custom/hooks")
+				SystemBackupCmd.Flags().Set(skipImagesFlag, "true")
+				SystemBackupCmd.Flags().Set(skipPVsFlag, "true")
+				SystemBackupCmd.Flags().Set(common.OutputFlagName, "true")
 
-				expected := utils.FormatScriptFilePath(
-					utils.InstallDir()+staticPart,
-				) + args
+				expectedConfig := provider.SystemBackupConfig{
+					BackupFile:         customFile,
+					AdditionalHooksDir: "/custom/hooks",
+					SkipImages:         true,
+					SkipPVs:            true,
+					ShowOutput:         true,
+				}
 
-				resetBackupFlags()
-				flags := SystemBackupCmd.Flags()
-				flags.Set(backupFileFlag, `C:\temp\backup.zip`)
-				flags.Set(common.AdditionalHooksDirFlagName, "hooksDir")
+				mockSys.On("Backup", expectedConfig).Return(nil).Once()
 
-				actual := createSystemBackupPsCommand(SystemBackupCmd)
+				err := runSystemBackup(SystemBackupCmd, nil)
 
-				Expect(actual).To(Equal(expected))
+				Expect(err).ToNot(HaveOccurred())
+				mockSys.AssertExpectations(GinkgoT())
+			})
+		})
+
+		When("provider Backup returns an error", func() {
+			It("returns the error", func() {
+				expectedErr := errors.New("backup failed")
+				mockSys.On("Backup", mock.Anything).Return(expectedErr).Once()
+
+				err := runSystemBackup(SystemBackupCmd, nil)
+
+				Expect(err).To(MatchError(expectedErr))
+				mockSys.AssertExpectations(GinkgoT())
 			})
 		})
 	})

--- a/cmd/linkerdproxyidentity/main.go
+++ b/cmd/linkerdproxyidentity/main.go
@@ -16,6 +16,8 @@ import (
 
 const proxyExecutable = "linkerd2-proxy.exe"
 const bootstrapOnlyEnvironment = "LINKERD2_PROXY_IDENTITY_BOOTSTRAP_ONLY"
+const identityDirEnvironment = "LINKERD2_PROXY_IDENTITY_DIR"
+const identityTokenFileEnvironment = "LINKERD2_PROXY_IDENTITY_TOKEN_FILE"
 
 var executablePath = os.Executable
 
@@ -31,7 +33,10 @@ func main() {
 }
 
 func run(args []string, getenv func(string) string, stdin, stdout, stderr *os.File) error {
-	identityDir := normalizeIdentityDir(getenv("LINKERD2_PROXY_IDENTITY_DIR"), getenv("SystemDrive"), runtime.GOOS == "windows")
+	isWindows := runtime.GOOS == "windows"
+	systemDrive := getenv("SystemDrive")
+	identityDir := normalizeUnixPath(getenv(identityDirEnvironment), systemDrive, isWindows)
+	tokenFile := normalizeUnixPath(getenv(identityTokenFileEnvironment), systemDrive, isWindows)
 	localName := getenv("LINKERD2_PROXY_IDENTITY_LOCAL_NAME")
 	trustAnchors := getenv("LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS")
 
@@ -47,7 +52,7 @@ func run(args []string, getenv func(string) string, stdin, stdout, stderr *os.Fi
 		return fmt.Errorf("resolve proxy identity executable path: %w", err)
 	}
 	proxy := commandRunner(filepath.Join(filepath.Dir(identityExecutable), proxyExecutable), args...)
-	proxy.Env = identityEnvironment(identityDir)
+	proxy.Env = identityEnvironment(identityDir, tokenFile)
 	proxy.Stdin = stdin
 	proxy.Stdout = stdout
 	proxy.Stderr = stderr
@@ -57,25 +62,29 @@ func run(args []string, getenv func(string) string, stdin, stdout, stderr *os.Fi
 	return nil
 }
 
-func normalizeIdentityDir(identityDir, systemDrive string, isWindows bool) string {
-	if !isWindows || !strings.HasPrefix(identityDir, "/") || strings.HasPrefix(identityDir, "//") {
-		return identityDir
+func normalizeUnixPath(path, systemDrive string, isWindows bool) string {
+	if !isWindows || !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") {
+		return path
 	}
 	if systemDrive == "" {
 		systemDrive = "C:"
 	}
 	systemDrive = strings.TrimRight(systemDrive, `\\/`)
-	return filepath.FromSlash(systemDrive + identityDir)
+	return filepath.FromSlash(systemDrive + path)
 }
 
-func identityEnvironment(identityDir string) []string {
-	environment := make([]string, 0, len(os.Environ())+1)
+func identityEnvironment(identityDir, tokenFile string) []string {
+	environment := make([]string, 0, len(os.Environ())+2)
 	for _, value := range os.Environ() {
-		if !strings.HasPrefix(value, "LINKERD2_PROXY_IDENTITY_DIR=") {
-			environment = append(environment, value)
+		if strings.HasPrefix(value, identityDirEnvironment+"=") || strings.HasPrefix(value, identityTokenFileEnvironment+"=") {
+			continue
 		}
+		environment = append(environment, value)
 	}
-	return append(environment, "LINKERD2_PROXY_IDENTITY_DIR="+identityDir)
+	return append(environment,
+		identityDirEnvironment+"="+identityDir,
+		identityTokenFileEnvironment+"="+tokenFile,
+	)
 }
 
 func exitCode(err error) int {

--- a/docs/op-manual/backing-up-restoring-system.md
+++ b/docs/op-manual/backing-up-restoring-system.md
@@ -10,11 +10,14 @@ This guide explains how to back up and restore your entire K2s cluster state, in
 
 ## Overview
 
-K2s provides comprehensive backup and restore functionality for your cluster:
+K2s provides comprehensive backup and restore functionality for your cluster across supported platforms:
 
-- **`k2s system backup`**: Creates a complete backup of cluster resources, persistent volumes, and container images
+- **`k2s system backup`**: Creates a complete backup of cluster resources, persistent volumes, and container images (supported on both Windows and Linux hosts)
 - **`k2s system restore`**: Restores cluster state from a backup archive
 - **Integration with Upgrade**: The `k2s system upgrade` command automatically creates a backup before upgrading
+
+!!! tip "Dual-Platform Support"
+    `k2s system backup` runs natively on both **Windows** (using PowerShell automation) and **Linux** hosts (using Go native orchestration and CLI tools).
 
 ## Configuration Settings
 
@@ -73,37 +76,50 @@ k2s system backup [options]
 
 | Option | Short | Description | Required |
 |--------|-------|-------------|----------|
-| `--file` | `-f` | Path to backup archive file (`.zip`) | Yes |
+| `--file` | `-f` | Path to backup archive file (`.zip`). Defaults to temp directory if omitted. | No |
 | `--skip-images` | | Skip container image backup (faster, smaller backup) | No |
 | `--skip-pvs` | | Skip persistent volume backup | No |
-| `--output-style` | `-o` | Output style (standard, verbose, structured) | No |
-| `--show-logs` | `-v` | Show detailed logs during backup | No |
+| `--additional-hooks-dir` | | Directory with additional custom hook scripts | No |
+| `--output` | `-o` | Show command output in terminal | No |
+| `--verbosity` | `-v` | Log level verbosity (`debug`, `info`, `warn`, `error`) | No |
 | `--help` | `-h` | Display help information | No |
 
 ### Examples
 
 #### Full Backup (All Resources, Images, and PVs)
 
+Windows:
 ```console
-k2s system backup -f c:\backups\k2s-full-backup.zip
+k2s system backup -f C:\backups\k2s-full-backup.zip
+```
+
+Linux:
+```console
+k2s system backup -f /tmp/backups/k2s-full-backup.zip
 ```
 
 #### Quick Backup (Skip Images for Speed)
 
+Windows:
 ```console
-k2s system backup -f c:\backups\k2s-quick.zip --skip-images
+k2s system backup -f C:\backups\k2s-quick.zip --skip-images
+```
+
+Linux:
+```console
+k2s system backup -f /tmp/backups/k2s-quick.zip --skip-images
 ```
 
 #### Configuration-Only Backup (No Images or PVs)
 
 ```console
-k2s system backup -f c:\backups\k2s-config.zip --skip-images --skip-pvs
+k2s system backup -f /tmp/backups/k2s-config.zip --skip-images --skip-pvs
 ```
 
-#### Verbose Backup with Detailed Logs
+#### Verbose Backup with Terminal Output
 
 ```console
-k2s system backup -f c:\backups\k2s-backup.zip -o -v
+k2s system backup -f /tmp/backups/k2s-backup.zip -o -v debug
 ```
 
 ## Backup Contents
@@ -122,9 +138,8 @@ Namespaced/
 NotNamespaced/
   <resource-type>.yaml   # Cluster-scoped resources
 pv/
-  <pv-name>/
-    data/                # Persistent volume data
-    metadata.json        # PV metadata
+  <pv-name>-backup.tar.gz       # Compressed persistent volume data
+  <pv-name>-backup-metadata.json # PV metadata (capacity, claim binding, reclaim policy)
 images/
   <image-name>.tar       # Container images (nerdctl save format)
 hooks/
@@ -239,12 +254,13 @@ k2s system backup -f backup.zip
 
 ## Custom Backup Hooks
 
-K2s supports custom backup logic via hooks:
+K2s supports custom backup logic via hooks on both Windows and Linux:
 
 ### Hook Locations
 
-- **Built-in**: `lib/scripts/windows/host/system/backup/hooks/`
-- **Custom**: Specify with `--additional-hooks-dir` flag
+- **Addon hooks**: `addons/**/Backup.ps1` (Windows) or `addons/**/Backup.sh` (Linux)
+- **Built-in hooks**: `lib/scripts/windows/host/system/backup/hooks/` (Windows)
+- **Custom hooks**: Specify with `--additional-hooks-dir` flag containing `*.Backup.ps1` (Windows) or `*.Backup.sh` / `*.sh` (Linux)
 
 ### Hook Types
 
@@ -252,7 +268,9 @@ K2s supports custom backup logic via hooks:
 - **Post-backup**: Execute after backup completes
 - **Resource-specific**: Execute for specific resource types
 
-### Hook Example
+### Hook Examples
+
+#### Windows PowerShell Hook Example
 
 ```powershell
 # hooks/my-app-backup.ps1
@@ -267,6 +285,34 @@ Write-Host "Executing custom backup logic for my-app..."
 kubectl exec -n my-app my-db-0 -- pg_dump mydb > "$BackupDir/my-app-db.sql"
 
 Write-Host "Custom backup complete"
+```
+
+#### Linux Bash Hook Example
+
+```bash
+#!/usr/bin/env bash
+# hooks/my-app-backup.sh
+set -euo pipefail
+
+BACKUP_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --backup-dir)
+      BACKUP_DIR="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+echo "Executing custom backup logic for my-app..."
+
+# Example: Dump database to file
+kubectl exec -n my-app my-db-0 -- pg_dump mydb > "${BACKUP_DIR}/my-app-db.sql"
+
+echo "Custom backup complete"
 ```
 
 For more details on hooks, see [Hook System Documentation](hook-system.md).

--- a/docs/user-guide/hosting-variants.md
+++ b/docs/user-guide/hosting-variants.md
@@ -17,7 +17,7 @@ In this variant, the focus is on setting up an environment solely for building a
 ## Linux Host
 
 !!! warning "Experimental"
-    Linux host support is experimental. Some features (offline packaging, backup/restore) are not yet available. The interface may change without notice.
+    Linux host support is experimental. Some features (offline packaging, system restore) are not yet available. The interface may change without notice.
 
 In this variant the *Linux* machine **is** the host. The *Kubernetes* control plane runs natively on the host (no VM), and an optional *Windows* VM is provisioned via *libvirt/KVM* with OVMF UEFI firmware to provide a mixed-OS worker node.
 

--- a/docs/user-guide/k2s-cli.md
+++ b/docs/user-guide/k2s-cli.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MIT
 The *k2s* CLI is the primary interface for managing a *K2s* cluster. It covers the full lifecycle — installation, startup, upgrade, image management, addon management, and system maintenance.
 
 !!! warning "Linux Host Support — Experimental"
-    Running the *k2s* CLI on a **Linux host** is an experimental feature. Core cluster lifecycle commands (`install`, `start`, `stop`, `uninstall`, `status`) and image/addon management work, but some system commands (`system upgrade`, `system package`, `system backup/restore`) are not yet implemented on Linux. See [Hosting Variants](hosting-variants.md#linux-host) for details.
+    Running the *k2s* CLI on a **Linux host** is an experimental feature. Core cluster lifecycle commands (`install`, `start`, `stop`, `uninstall`, `status`), image/addon management, and `system backup` work, but some system commands (`system upgrade`, `system package`, `system restore`) are not yet implemented on Linux. See [Hosting Variants](hosting-variants.md#linux-host) for details.
 
 Every command supports `--output` / `-o` (show log in terminal) and `--verbosity` / `-v` (log level, default `info`) as global flags.
 
@@ -515,7 +515,7 @@ k2s system package --node-package --os debian13 --include-gpu --target-dir "C:\o
 
 ### system backup
 
-Back up the cluster (resources, persistent volumes, user images).
+Back up the cluster (resources, persistent volumes, user images). Supported on both Windows and Linux hosts.
 
 ```console
 k2s system backup [flags]
@@ -523,10 +523,24 @@ k2s system backup [flags]
 
 | Flag | Short | Description |
 |------|-------|-------------|
-| `--file` | `-f` | Output zip file path |
+| `--file` | `-f` | Output zip file path (default: temp directory) |
 | `--skip-images` | | Skip container image backup |
 | `--skip-pvs` | | Skip persistent volume backup |
 | `--additional-hooks-dir` | | Directory with additional hook scripts |
+| `--output` | `-o` | Show command output in terminal |
+
+**Examples:**
+
+```console
+# Full backup (Windows)
+k2s system backup -f C:\backups\k2s-backup.zip
+
+# Full backup (Linux)
+k2s system backup -f /tmp/backups/k2s-backup.zip
+
+# Fast backup skipping images and persistent volumes with output display
+k2s system backup -f /tmp/backups/k2s-backup.zip --skip-images --skip-pvs -o
+```
 
 ### system restore
 

--- a/internal/provider/system_backup_linux.go
+++ b/internal/provider/system_backup_linux.go
@@ -1,0 +1,932 @@
+// SPDX-FileCopyrightText:  © 2026 Siemens Healthineers AG
+// SPDX-License-Identifier:   MIT
+
+//go:build linux
+
+package provider
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/siemens-healthineers/k2s/internal/version"
+	"gopkg.in/yaml.v3"
+)
+
+type rawBackupConfigJSON struct {
+	SmallSetup struct {
+		Backup struct {
+			ExcludedNamespaces             string `json:"excludednamespaces"`
+			ExcludedNamespacedResources    string `json:"excludednamespacedresources"`
+			ExcludedClusterResources       string `json:"excludedclusterresources"`
+			ExcludedAddonPersistentVolumes string `json:"excludedaddonpersistentvolumes"`
+		} `json:"backup"`
+	} `json:"smallsetup"`
+	Backup struct {
+		ExcludedNamespaces             string `json:"excludednamespaces"`
+		ExcludedNamespacedResources    string `json:"excludednamespacedresources"`
+		ExcludedClusterResources       string `json:"excludedclusterresources"`
+		ExcludedAddonPersistentVolumes string `json:"excludedaddonpersistentvolumes"`
+	} `json:"backup"`
+	ClusterName string `json:"clusterName"`
+}
+
+type backupConfig struct {
+	ExcludedNamespaces             []string
+	ExcludedNamespacedResources    []string
+	ExcludedClusterResources       []string
+	ExcludedAddonPersistentVolumes []string
+	ClusterName                    string
+}
+
+type backupManifest struct {
+	APIVersion     string                 `json:"apiVersion"`
+	Kind           string                 `json:"kind"`
+	Metadata       backupManifestMetadata `json:"metadata"`
+	Cluster        backupManifestCluster  `json:"cluster"`
+	Content        backupManifestContent  `json:"content"`
+	ConfigSnapshot backupConfigSnapshot   `json:"configSnapshot"`
+}
+
+type backupManifestMetadata struct {
+	BackupTimestamp     string `json:"backupTimestamp"`
+	BackupTool          string `json:"backupTool"`
+	BackupToolVersion   string `json:"backupToolVersion"`
+	BackupFormatVersion string `json:"backupFormatVersion"`
+}
+
+type backupManifestCluster struct {
+	Name       string `json:"name"`
+	K2sVersion string `json:"k2sVersion"`
+}
+
+type backupManifestContent struct {
+	Included backupContentIncluded `json:"included"`
+	Excluded backupContentExcluded `json:"excluded"`
+}
+
+type backupContentIncluded struct {
+	ClusterResources bool     `json:"clusterResources"`
+	Namespaces       []string `json:"namespaces"`
+}
+
+type backupContentExcluded struct {
+	Namespaces          []string `json:"namespaces"`
+	NamespacedResources []string `json:"namespacedResources"`
+	ClusterResources    []string `json:"clusterResources"`
+}
+
+type backupConfigSnapshot struct {
+	Source string `json:"source"`
+}
+
+type k8sPVList struct {
+	Items []k8sPVItem `json:"items"`
+}
+
+type k8sPVItem struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		Capacity struct {
+			Storage string `json:"storage"`
+		} `json:"capacity"`
+		HostPath *struct {
+			Path string `json:"path"`
+		} `json:"hostPath"`
+		Local *struct {
+			Path string `json:"path"`
+		} `json:"local"`
+		ClaimRef *struct {
+			Namespace string `json:"namespace"`
+			Name      string `json:"name"`
+		} `json:"claimRef"`
+		PersistentVolumeReclaimPolicy string `json:"persistentVolumeReclaimPolicy"`
+	} `json:"spec"`
+	Status struct {
+		Phase string `json:"phase"`
+	} `json:"status"`
+}
+
+func runLinuxSystemBackup(installDir string, cfg SystemBackupConfig) error {
+	slog.Info("[System Backup] Starting K2s system backup...")
+
+	if cfg.BackupFile == "" {
+		return fmt.Errorf("backup file path must not be empty")
+	}
+
+	absBackupFile, err := filepath.Abs(cfg.BackupFile)
+	if err != nil {
+		return fmt.Errorf("invalid backup file path '%s': %w", cfg.BackupFile, err)
+	}
+
+	targetDir := filepath.Dir(absBackupFile)
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("failed to create backup directory '%s': %w", targetDir, err)
+	}
+
+	stagingDir, err := os.MkdirTemp(targetDir, "k2s-backup-staging-")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary staging directory: %w", err)
+	}
+	defer func() {
+		slog.Debug("[System Backup] Cleaning up staging directory", "dir", stagingDir)
+		_ = os.RemoveAll(stagingDir)
+	}()
+
+	slog.Info("[System Backup] Using staging directory", "dir", stagingDir)
+
+	// Step 1: Check cluster connectivity
+	if err := checkClusterReachable(); err != nil {
+		return err
+	}
+
+	// Step 2: Load configuration exclusions & cluster name
+	backupCfg := loadBackupConfig(installDir)
+
+	// Step 3: Export Namespaced and Cluster resources
+	includedNamespaces, err := exportClusterResources(stagingDir, backupCfg)
+	if err != nil {
+		return fmt.Errorf("failed to export cluster resources: %w", err)
+	}
+
+	// Step 4: Backup Persistent Volumes
+	if cfg.SkipPVs {
+		slog.Info("[System Backup] Skipping PV backup as requested")
+	} else {
+		if err := backupPersistentVolumes(stagingDir, backupCfg); err != nil {
+			return fmt.Errorf("failed to backup persistent volumes: %w", err)
+		}
+	}
+
+	// Step 5: Backup Container Images
+	if cfg.SkipImages {
+		slog.Info("[System Backup] Skipping image backup as requested")
+	} else {
+		if err := backupContainerImages(stagingDir, includedNamespaces); err != nil {
+			return fmt.Errorf("failed to backup container images: %w", err)
+		}
+	}
+
+	// Step 6: Execute Backup Hooks
+	executeBackupHooks(installDir, stagingDir, cfg.AdditionalHooksDir)
+
+	// Step 7: Snapshot config.json
+	snapshotConfig(installDir, stagingDir)
+
+	// Step 8: Generate backup.json manifest
+	if err := generateBackupManifest(stagingDir, backupCfg, includedNamespaces); err != nil {
+		return fmt.Errorf("failed to generate backup.json manifest: %w", err)
+	}
+
+	// Step 9: Create final ZIP archive
+	slog.Info("[System Backup] Creating backup archive", "path", absBackupFile)
+	if err := createZipFromDirectory(stagingDir, absBackupFile); err != nil {
+		return fmt.Errorf("failed to create backup archive '%s': %w", absBackupFile, err)
+	}
+
+	slog.Info("[System Backup] System backup completed successfully", "file", absBackupFile)
+	return nil
+}
+
+func checkClusterReachable() error {
+	slog.Info("[System Backup] Checking cluster status...")
+	cmd := exec.Command("kubectl", "cluster-info", "--request-timeout=5s")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("Kubernetes cluster is not reachable: %w: %s", err, string(out))
+	}
+	return nil
+}
+
+func loadBackupConfig(installDir string) *backupConfig {
+	cfg := &backupConfig{
+		ExcludedNamespaces: []string{
+			"kube-flannel", "kube-node-lease", "kube-public", "kube-system",
+			"k2s-webhook", "kubernetes-dashboard", "nginx-gw", "gpu-node",
+			"ingress-nginx", "kubevirt", "monitoring", "registry", "dicom",
+			"ingress-traefik", "logging", "security", "viewer", "storage-smb",
+			"linkerd", "cert-manager", "dashboard", "autoscaling", "metrics", "rollout",
+		},
+		ExcludedNamespacedResources: []string{
+			"endpoints", "endpointslices", "events",
+		},
+		ExcludedClusterResources: []string{
+			"componentstatuses", "nodes", "csinodes", "ipaddresses",
+			"certificatesigningrequests", "storageclasses", "servicecidrs",
+			"apiservices", "flowschemas", "prioritylevelconfigurations",
+			"ingressclasses", "runtimeclasses", "mutatingwebhookconfigurations",
+		},
+		ExcludedAddonPersistentVolumes: []string{
+			"postgresql-pv-volume", "dicom-pv-volume", "orthanc-pv",
+			"registry-pv", "smb-static-pv", "opensearch-cluster-master-pv",
+		},
+		ClusterName: "k2s-cluster",
+	}
+
+	configPath := filepath.Join(installDir, "cfg", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		slog.Warn("[System Backup] Could not read config.json, using defaults", "path", configPath, "error", err)
+		return cfg
+	}
+
+	var raw rawBackupConfigJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		slog.Warn("[System Backup] Could not parse config.json, using defaults", "error", err)
+		return cfg
+	}
+
+	if raw.ClusterName != "" {
+		cfg.ClusterName = raw.ClusterName
+	}
+
+	b := raw.SmallSetup.Backup
+	if b.ExcludedNamespaces == "" && raw.Backup.ExcludedNamespaces != "" {
+		b = raw.Backup
+	}
+
+	if b.ExcludedNamespaces != "" {
+		cfg.ExcludedNamespaces = splitAndTrim(b.ExcludedNamespaces)
+	}
+	if b.ExcludedNamespacedResources != "" {
+		cfg.ExcludedNamespacedResources = splitAndTrim(b.ExcludedNamespacedResources)
+	}
+	if b.ExcludedClusterResources != "" {
+		cfg.ExcludedClusterResources = splitAndTrim(b.ExcludedClusterResources)
+	}
+	if b.ExcludedAddonPersistentVolumes != "" {
+		cfg.ExcludedAddonPersistentVolumes = splitAndTrim(b.ExcludedAddonPersistentVolumes)
+	}
+
+	return cfg
+}
+
+func splitAndTrim(s string) []string {
+	parts := strings.Split(s, ",")
+	var res []string
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			res = append(res, trimmed)
+		}
+	}
+	return res
+}
+
+func containsString(slice []string, val string) bool {
+	for _, item := range slice {
+		if strings.EqualFold(item, val) {
+			return true
+		}
+	}
+	return false
+}
+
+func exportClusterResources(stagingDir string, bcfg *backupConfig) ([]string, error) {
+	slog.Info("[System Backup] Exporting cluster resources...")
+
+	// 1. Get all namespaces
+	out, err := exec.Command("kubectl", "get", "namespaces", "-o", "jsonpath={.items[*].metadata.name}").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespaces: %w: %s", err, string(out))
+	}
+
+	allNamespaces := strings.Fields(string(out))
+	var includedNamespaces []string
+	for _, ns := range allNamespaces {
+		if !containsString(bcfg.ExcludedNamespaces, ns) {
+			includedNamespaces = append(includedNamespaces, ns)
+		}
+	}
+
+	// 2. Export Namespaced Resources
+	namespacedResOut, err := exec.Command("kubectl", "api-resources", "--namespaced=true", "--verbs=list").CombinedOutput()
+	if err != nil {
+		slog.Warn("[System Backup] Failed to query namespaced api-resources", "error", err)
+	} else {
+		var namespacedTypes []string
+		for _, line := range strings.Split(string(namespacedResOut), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 0 || fields[0] == "NAME" {
+				continue
+			}
+			resName := fields[0]
+			if !containsString(bcfg.ExcludedNamespacedResources, resName) && !containsString(namespacedTypes, resName) {
+				namespacedTypes = append(namespacedTypes, resName)
+			}
+		}
+
+		for _, ns := range includedNamespaces {
+			nsDir := filepath.Join(stagingDir, "Namespaced", ns)
+			if err := os.MkdirAll(nsDir, 0755); err != nil {
+				return nil, err
+			}
+
+			for _, resType := range namespacedTypes {
+				resJSON, err := exec.Command("kubectl", "get", resType, "-n", ns, "-o", "json").Output()
+				if err != nil {
+					continue
+				}
+
+				yamlBytes, hasItems, err := cleanAndConvertResourceJSON(resJSON)
+				if err != nil || !hasItems {
+					continue
+				}
+
+				outFile := filepath.Join(nsDir, resType+".yaml")
+				if err := os.WriteFile(outFile, yamlBytes, 0644); err != nil {
+					slog.Warn("[System Backup] Failed to write namespaced resource yaml", "file", outFile, "error", err)
+				}
+			}
+		}
+	}
+
+	// 3. Export Cluster-scoped Resources
+	clusterResOut, err := exec.Command("kubectl", "api-resources", "--namespaced=false", "--verbs=list").CombinedOutput()
+	if err != nil {
+		slog.Warn("[System Backup] Failed to query cluster-scoped api-resources", "error", err)
+	} else {
+		notNamespacedDir := filepath.Join(stagingDir, "NotNamespaced")
+		_ = os.MkdirAll(notNamespacedDir, 0755)
+
+		var clusterTypes []string
+		for _, line := range strings.Split(string(clusterResOut), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 0 || fields[0] == "NAME" {
+				continue
+			}
+			resName := fields[0]
+			if !containsString(bcfg.ExcludedClusterResources, resName) && !containsString(clusterTypes, resName) {
+				clusterTypes = append(clusterTypes, resName)
+			}
+		}
+
+		for _, resType := range clusterTypes {
+			resJSON, err := exec.Command("kubectl", "get", resType, "-o", "json").Output()
+			if err != nil {
+				continue
+			}
+
+			yamlBytes, hasItems, err := cleanAndConvertResourceJSON(resJSON)
+			if err != nil || !hasItems {
+				continue
+			}
+
+			outFile := filepath.Join(notNamespacedDir, resType+".yaml")
+			if err := os.WriteFile(outFile, yamlBytes, 0644); err != nil {
+				slog.Warn("[System Backup] Failed to write cluster resource yaml", "file", outFile, "error", err)
+			}
+		}
+	}
+
+	return includedNamespaces, nil
+}
+
+func cleanAndConvertResourceJSON(rawJSON []byte) ([]byte, bool, error) {
+	var data map[string]any
+	if err := json.Unmarshal(rawJSON, &data); err != nil {
+		return nil, false, err
+	}
+
+	if items, ok := data["items"].([]any); ok && len(items) == 0 {
+		return nil, false, nil
+	}
+
+	cleanResourceMap(data)
+
+	yamlBytes, err := yaml.Marshal(data)
+	if err != nil {
+		return nil, false, err
+	}
+	return yamlBytes, true, nil
+}
+
+func cleanResourceMap(data map[string]any) {
+	if items, ok := data["items"].([]any); ok {
+		for _, item := range items {
+			if itemMap, ok := item.(map[string]any); ok {
+				cleanSingleResource(itemMap)
+			}
+		}
+	} else {
+		cleanSingleResource(data)
+	}
+	cleanMetadata(data)
+}
+
+func cleanSingleResource(m map[string]any) {
+	delete(m, "status")
+	cleanMetadata(m)
+	if spec, ok := m["spec"].(map[string]any); ok {
+		delete(spec, "finalizers")
+		delete(spec, "claimRef")
+	}
+}
+
+func cleanMetadata(m map[string]any) {
+	if meta, ok := m["metadata"].(map[string]any); ok {
+		delete(meta, "creationTimestamp")
+		delete(meta, "resourceVersion")
+		delete(meta, "uid")
+		delete(meta, "selfLink")
+		delete(meta, "generation")
+		delete(meta, "managedFields")
+		delete(meta, "ownerReferences")
+		if annotations, ok := meta["annotations"].(map[string]any); ok {
+			delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
+			if len(annotations) == 0 {
+				delete(meta, "annotations")
+			}
+		}
+	}
+}
+
+func backupPersistentVolumes(stagingDir string, bcfg *backupConfig) error {
+	slog.Info("[System Backup] Backing up persistent volumes...")
+	pvDir := filepath.Join(stagingDir, "pv")
+
+	out, err := exec.Command("kubectl", "get", "pv", "-o", "json").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to query persistent volumes: %w: %s", err, string(out))
+	}
+
+	var pvList k8sPVList
+	if err := json.Unmarshal(out, &pvList); err != nil {
+		return fmt.Errorf("failed to parse pv list: %w", err)
+	}
+
+	if err := os.MkdirAll(pvDir, 0755); err != nil {
+		return err
+	}
+
+	backedUpCount := 0
+	for _, pv := range pvList.Items {
+		pvName := pv.Metadata.Name
+		if pvName == "" || containsString(bcfg.ExcludedAddonPersistentVolumes, pvName) {
+			continue
+		}
+
+		var volumeType, volumePath string
+		if pv.Spec.HostPath != nil && pv.Spec.HostPath.Path != "" {
+			volumeType = "hostPath"
+			volumePath = pv.Spec.HostPath.Path
+		} else if pv.Spec.Local != nil && pv.Spec.Local.Path != "" {
+			volumeType = "local"
+			volumePath = pv.Spec.Local.Path
+		} else {
+			continue
+		}
+
+		stat, err := os.Stat(volumePath)
+		if err != nil {
+			slog.Warn("[System Backup] PV volume path not accessible", "pv", pvName, "path", volumePath, "error", err)
+			continue
+		}
+
+		targetTarGz := filepath.Join(pvDir, pvName+"-backup.tar.gz")
+		if stat.IsDir() {
+			if err := tarGzDirectory(volumePath, targetTarGz); err != nil {
+				slog.Warn("[System Backup] Failed to archive PV directory", "pv", pvName, "error", err)
+				continue
+			}
+		} else {
+			if err := tarGzSingleFile(volumePath, targetTarGz); err != nil {
+				slog.Warn("[System Backup] Failed to archive PV file", "pv", pvName, "error", err)
+				continue
+			}
+		}
+
+		claimNs := ""
+		claimName := ""
+		if pv.Spec.ClaimRef != nil {
+			claimNs = pv.Spec.ClaimRef.Namespace
+			claimName = pv.Spec.ClaimRef.Name
+		}
+
+		metadata := map[string]any{
+			"version":        "1.0",
+			"backupType":     "persistent-volume",
+			"pvName":         pvName,
+			"volumeType":     volumeType,
+			"volumePath":     volumePath,
+			"capacity":       pv.Spec.Capacity.Storage,
+			"createdAt":      time.Now().UTC().Format(time.RFC3339),
+			"backupFile":     pvName + "-backup.tar.gz",
+			"claimNamespace": claimNs,
+			"claimName":      claimName,
+			"reclaimPolicy":  pv.Spec.PersistentVolumeReclaimPolicy,
+		}
+
+		metaJSON, _ := json.MarshalIndent(metadata, "", "  ")
+		_ = os.WriteFile(filepath.Join(pvDir, pvName+"-backup-metadata.json"), metaJSON, 0644)
+		backedUpCount++
+	}
+
+	slog.Info("[System Backup] Successfully backed up persistent volumes", "count", backedUpCount)
+	return nil
+}
+
+func tarGzDirectory(srcDir, destTarGz string) error {
+	out, err := os.Create(destTarGz)
+	if err != nil {
+		return err
+	}
+	gw := gzip.NewWriter(out)
+	tw := tar.NewWriter(gw)
+
+	var closed bool
+	defer func() {
+		if !closed {
+			_ = tw.Close()
+			_ = gw.Close()
+			_ = out.Close()
+		}
+	}()
+
+	err = filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+
+		header, err := tar.FileInfoHeader(info, info.Name())
+		if err != nil {
+			return err
+		}
+		header.Name = filepath.ToSlash(relPath)
+
+		if info.IsDir() {
+			header.Name += "/"
+			return tw.WriteHeader(header)
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			header.Linkname = linkTarget
+			return tw.WriteHeader(header)
+		}
+
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = io.Copy(tw, file)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("failed to close tar writer: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("failed to close archive file '%s': %w", destTarGz, err)
+	}
+	closed = true
+
+	return nil
+}
+
+func tarGzSingleFile(srcFile, destTarGz string) error {
+	out, err := os.Create(destTarGz)
+	if err != nil {
+		return err
+	}
+	gw := gzip.NewWriter(out)
+	tw := tar.NewWriter(gw)
+
+	var closed bool
+	defer func() {
+		if !closed {
+			_ = tw.Close()
+			_ = gw.Close()
+			_ = out.Close()
+		}
+	}()
+
+	info, err := os.Stat(srcFile)
+	if err != nil {
+		return err
+	}
+
+	header, err := tar.FileInfoHeader(info, info.Name())
+	if err != nil {
+		return err
+	}
+	header.Name = filepath.Base(srcFile)
+
+	if err := tw.WriteHeader(header); err != nil {
+		return err
+	}
+
+	file, err := os.Open(srcFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(tw, file); err != nil {
+		return err
+	}
+
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("failed to close tar writer: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("failed to close archive file '%s': %w", destTarGz, err)
+	}
+	closed = true
+
+	return nil
+}
+
+func backupContainerImages(stagingDir string, includedNamespaces []string) error {
+	slog.Info("[System Backup] Backing up user workload images...")
+	imagesDir := filepath.Join(stagingDir, "images")
+	if err := os.MkdirAll(imagesDir, 0755); err != nil {
+		return err
+	}
+
+	imageSet := make(map[string]struct{})
+	queryFailures := 0
+	for _, ns := range includedNamespaces {
+		out, err := exec.Command("kubectl", "get", "pods", "-n", ns,
+			"-o", "jsonpath={.items[*].spec.containers[*].image} {.items[*].spec.initContainers[*].image}").Output()
+		if err != nil {
+			queryFailures++
+			slog.Warn("[System Backup] Failed to query pods for namespace", "namespace", ns, "error", err)
+			continue
+		}
+		for _, img := range strings.Fields(string(out)) {
+			img = strings.TrimSpace(img)
+			if img != "" {
+				imageSet[img] = struct{}{}
+			}
+		}
+	}
+
+	if len(includedNamespaces) > 0 && queryFailures == len(includedNamespaces) {
+		return fmt.Errorf("failed to query pod images: all %d namespace queries failed", queryFailures)
+	}
+
+	backedUpCount := 0
+	for img := range imageSet {
+		sanitized := sanitizeImageName(img) + ".tar"
+		targetTar := filepath.Join(imagesDir, sanitized)
+
+		// Try ctr (containerd in k8s.io namespace) first
+		cmd := exec.Command("ctr", "-n", "k8s.io", "images", "export", targetTar, img)
+		if err := cmd.Run(); err != nil {
+			// Fall back to nerdctl or docker
+			cmd2 := exec.Command("nerdctl", "-n", "k8s.io", "save", "-o", targetTar, img)
+			if err2 := cmd2.Run(); err2 != nil {
+				cmd3 := exec.Command("docker", "save", "-o", targetTar, img)
+				if err3 := cmd3.Run(); err3 != nil {
+					slog.Warn("[System Backup] Failed to export image", "image", img, "error", err3)
+					continue
+				}
+			}
+		}
+		backedUpCount++
+	}
+
+	slog.Info("[System Backup] Successfully backed up user workload container images", "count", backedUpCount)
+	return nil
+}
+
+func sanitizeImageName(image string) string {
+	r := strings.NewReplacer("/", "_", ":", "_", "@", "_")
+	return r.Replace(image)
+}
+
+func executeBackupHooks(installDir, stagingDir, additionalHooksDir string) {
+	hooksDir := filepath.Join(stagingDir, "hooks")
+	_ = os.MkdirAll(hooksDir, 0755)
+
+	slog.Info("[System Backup] Executing backup hooks...")
+
+	// Scan addon backup scripts
+	addonsRoot := filepath.Join(installDir, "addons")
+	_ = filepath.WalkDir(addonsRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if name == "Backup.sh" || strings.HasSuffix(name, ".Backup.sh") {
+			relPath, err := filepath.Rel(addonsRoot, path)
+			if err == nil {
+				parts := strings.Split(filepath.ToSlash(relPath), "/")
+				if len(parts) > 1 {
+					addonName := parts[0]
+					if !isAddonDeployed(addonName) {
+						slog.Debug("[System Backup] Skipping backup hook for disabled addon", "addon", addonName, "path", path)
+						return nil
+					}
+				}
+			}
+			runBackupHook(path, hooksDir)
+		}
+		return nil
+	})
+
+	// Scan additional hooks directory
+	if additionalHooksDir != "" {
+		_ = filepath.WalkDir(additionalHooksDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			name := d.Name()
+			if strings.HasSuffix(name, ".Backup.sh") || strings.HasSuffix(name, ".sh") {
+				runBackupHook(path, hooksDir)
+			}
+			return nil
+		})
+	}
+}
+
+func runBackupHook(scriptPath, hooksDir string) {
+	slog.Info("[System Backup] Running hook", "path", scriptPath)
+	cmd := exec.Command("bash", scriptPath, "--backup-dir", hooksDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		slog.Warn("[System Backup] Hook execution failed", "path", scriptPath, "error", err, "output", string(out))
+	} else {
+		slog.Debug("[System Backup] Hook output", "path", scriptPath, "output", string(out))
+	}
+}
+
+func snapshotConfig(installDir, stagingDir string) {
+	configDir := filepath.Join(stagingDir, "config")
+	_ = os.MkdirAll(configDir, 0755)
+
+	srcConfig := filepath.Join(installDir, "cfg", "config.json")
+	data, err := os.ReadFile(srcConfig)
+	if err != nil {
+		slog.Warn("[System Backup] config.json not found", "path", srcConfig)
+		return
+	}
+
+	destConfig := filepath.Join(configDir, "config.json")
+	if err := os.WriteFile(destConfig, data, 0644); err != nil {
+		slog.Warn("[System Backup] Failed to snapshot config.json", "error", err)
+	}
+}
+
+func generateBackupManifest(stagingDir string, bcfg *backupConfig, includedNamespaces []string) error {
+	slog.Info("[System Backup] Creating backup metadata (backup.json)...")
+
+	v := version.GetVersion().Version
+	if v == "" {
+		v = "1.0.0"
+	}
+
+	manifest := backupManifest{
+		APIVersion: "k2s.backup/v1",
+		Kind:       "SystemBackup",
+		Metadata: backupManifestMetadata{
+			BackupTimestamp:     time.Now().UTC().Format(time.RFC3339),
+			BackupTool:          "k2s system backup",
+			BackupToolVersion:   v,
+			BackupFormatVersion: "1",
+		},
+		Cluster: backupManifestCluster{
+			Name:       bcfg.ClusterName,
+			K2sVersion: v,
+		},
+		Content: backupManifestContent{
+			Included: backupContentIncluded{
+				ClusterResources: true,
+				Namespaces:       includedNamespaces,
+			},
+			Excluded: backupContentExcluded{
+				Namespaces:          bcfg.ExcludedNamespaces,
+				NamespacedResources: bcfg.ExcludedNamespacedResources,
+				ClusterResources:    bcfg.ExcludedClusterResources,
+			},
+		},
+		ConfigSnapshot: backupConfigSnapshot{
+			Source: "config/config.json",
+		},
+	}
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	manifestPath := filepath.Join(stagingDir, "backup.json")
+	return os.WriteFile(manifestPath, data, 0644)
+}
+
+func createZipFromDirectory(sourceDir, zipPath string) error {
+	_ = os.Remove(zipPath)
+
+	zipFile, err := os.Create(zipPath)
+	if err != nil {
+		return fmt.Errorf("failed to create zip file '%s': %w", zipPath, err)
+	}
+	zipWriter := zip.NewWriter(zipFile)
+
+	var closed bool
+	defer func() {
+		if !closed {
+			_ = zipWriter.Close()
+			_ = zipFile.Close()
+		}
+	}()
+
+	err = filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+
+		if relPath == "." {
+			return nil
+		}
+
+		zipEntryName := filepath.ToSlash(relPath)
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return fmt.Errorf("failed to create zip header for '%s': %w", path, err)
+		}
+
+		header.Name = zipEntryName
+		header.Method = zip.Deflate
+
+		if info.IsDir() {
+			header.Name += "/"
+			_, err = zipWriter.CreateHeader(header)
+			return err
+		}
+
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return fmt.Errorf("failed to create zip entry '%s': %w", zipEntryName, err)
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open file '%s': %w", path, err)
+		}
+		defer file.Close()
+
+		_, err = io.Copy(writer, file)
+		if err != nil {
+			return fmt.Errorf("failed to write file '%s' into zip: %w", path, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close zip writer: %w", err)
+	}
+	if err := zipFile.Close(); err != nil {
+		return fmt.Errorf("failed to close zip file '%s': %w", zipPath, err)
+	}
+	closed = true
+
+	return nil
+}

--- a/internal/provider/system_backup_linux_test.go
+++ b/internal/provider/system_backup_linux_test.go
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText:  © 2026 Siemens Healthineers AG
+// SPDX-License-Identifier:   MIT
+
+//go:build linux
+
+package provider
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+func TestLinuxSystemBackup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Linux System Backup Unit Tests", Label("unit", "ci", "linux", "backup"))
+}
+
+var _ = Describe("Linux System Backup", func() {
+	Describe("splitAndTrim", func() {
+		It("splits and trims comma-separated values", func() {
+			input := "  item1,  item2 ,item3  , , item4 "
+			expected := []string{"item1", "item2", "item3", "item4"}
+			Expect(splitAndTrim(input)).To(Equal(expected))
+		})
+
+		It("returns nil for empty input", func() {
+			Expect(splitAndTrim("")).To(BeNil())
+		})
+	})
+
+	Describe("containsString", func() {
+		It("matches strings case-insensitively", func() {
+			slice := []string{"Kube-System", "DEFAULT"}
+			Expect(containsString(slice, "kube-system")).To(BeTrue())
+			Expect(containsString(slice, "Default")).To(BeTrue())
+			Expect(containsString(slice, "other")).To(BeFalse())
+		})
+	})
+
+	Describe("sanitizeImageName", func() {
+		It("replaces special characters with underscores", func() {
+			input := "docker.io/library/busybox:1.36@sha256:abcdef"
+			expected := "docker.io_library_busybox_1.36_sha256_abcdef"
+			Expect(sanitizeImageName(input)).To(Equal(expected))
+		})
+	})
+
+	Describe("loadBackupConfig", func() {
+		When("config.json does not exist", func() {
+			It("returns default configuration values", func() {
+				tempDir := GinkgoT().TempDir()
+				cfg := loadBackupConfig(tempDir)
+
+				Expect(cfg).NotTo(BeNil())
+				Expect(cfg.ClusterName).To(Equal("k2s-cluster"))
+				Expect(cfg.ExcludedNamespaces).To(ContainElement("kube-system"))
+				Expect(cfg.ExcludedNamespacedResources).To(ContainElement("endpoints"))
+				Expect(cfg.ExcludedClusterResources).To(ContainElement("nodes"))
+				Expect(cfg.ExcludedAddonPersistentVolumes).To(ContainElement("postgresql-pv-volume"))
+			})
+		})
+
+		When("config.json exists with custom exclusions", func() {
+			It("loads the configured exclusions", func() {
+				tempDir := GinkgoT().TempDir()
+				cfgDir := filepath.Join(tempDir, "cfg")
+				Expect(os.MkdirAll(cfgDir, 0755)).To(Succeed())
+
+				customConfig := `{
+					"smallsetup": {
+						"backup": {
+							"excludednamespaces": "custom-ns1,custom-ns2",
+							"excludednamespacedresources": "custom-res1",
+							"excludedclusterresources": "custom-cres1",
+							"excludedaddonpersistentvolumes": "custom-pv1"
+						}
+					},
+					"clusterName": "my-custom-cluster"
+				}`
+				Expect(os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(customConfig), 0644)).To(Succeed())
+
+				cfg := loadBackupConfig(tempDir)
+				Expect(cfg).NotTo(BeNil())
+				Expect(cfg.ClusterName).To(Equal("my-custom-cluster"))
+				Expect(cfg.ExcludedNamespaces).To(Equal([]string{"custom-ns1", "custom-ns2"}))
+				Expect(cfg.ExcludedNamespacedResources).To(Equal([]string{"custom-res1"}))
+				Expect(cfg.ExcludedClusterResources).To(Equal([]string{"custom-cres1"}))
+				Expect(cfg.ExcludedAddonPersistentVolumes).To(Equal([]string{"custom-pv1"}))
+			})
+		})
+	})
+
+	Describe("cleanAndConvertResourceJSON", func() {
+		It("returns false when items list is empty", func() {
+			rawJSON := []byte(`{"apiVersion":"v1","items":[],"kind":"List","metadata":{"resourceVersion":""}}`)
+			bytes, hasItems, err := cleanAndConvertResourceJSON(rawJSON)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasItems).To(BeFalse())
+			Expect(bytes).To(BeNil())
+		})
+
+		It("strips runtime metadata and converts to YAML when items are present", func() {
+			rawJSON := []byte(`{
+				"apiVersion": "v1",
+				"kind": "List",
+				"metadata": {
+					"resourceVersion": "12345"
+				},
+				"items": [
+					{
+						"apiVersion": "v1",
+						"kind": "ConfigMap",
+						"metadata": {
+							"name": "my-config",
+							"namespace": "default",
+							"uid": "abc-123",
+							"resourceVersion": "999",
+							"creationTimestamp": "2026-01-01T00:00:00Z",
+							"generation": 1,
+							"managedFields": [{"manager": "kubectl"}],
+							"annotations": {
+								"kubectl.kubernetes.io/last-applied-configuration": "{}",
+								"custom.annotation": "keep-me"
+							}
+						},
+						"data": {
+							"key": "value"
+						},
+						"status": {
+							"phase": "Active"
+						}
+					}
+				]
+			}`)
+
+			bytes, hasItems, err := cleanAndConvertResourceJSON(rawJSON)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasItems).To(BeTrue())
+
+			var parsed map[string]any
+			Expect(yaml.Unmarshal(bytes, &parsed)).To(Succeed())
+
+			items := parsed["items"].([]any)
+			Expect(items).To(HaveLen(1))
+			item := items[0].(map[string]any)
+
+			Expect(item).NotTo(HaveKey("status"))
+			meta := item["metadata"].(map[string]any)
+			Expect(meta["name"]).To(Equal("my-config"))
+			Expect(meta).NotTo(HaveKey("uid"))
+			Expect(meta).NotTo(HaveKey("resourceVersion"))
+			Expect(meta).NotTo(HaveKey("creationTimestamp"))
+			Expect(meta).NotTo(HaveKey("generation"))
+			Expect(meta).NotTo(HaveKey("managedFields"))
+
+			annotations := meta["annotations"].(map[string]any)
+			Expect(annotations).To(HaveKeyWithValue("custom.annotation", "keep-me"))
+			Expect(annotations).NotTo(HaveKey("kubectl.kubernetes.io/last-applied-configuration"))
+		})
+	})
+
+	Describe("generateBackupManifest", func() {
+		It("writes a valid backup.json file", func() {
+			tempDir := GinkgoT().TempDir()
+			bcfg := &backupConfig{
+				ExcludedNamespaces:          []string{"kube-system"},
+				ExcludedNamespacedResources: []string{"endpoints"},
+				ExcludedClusterResources:    []string{"nodes"},
+				ClusterName:                 "test-cluster",
+			}
+
+			err := generateBackupManifest(tempDir, bcfg, []string{"default", "my-app"})
+			Expect(err).NotTo(HaveOccurred())
+
+			manifestPath := filepath.Join(tempDir, "backup.json")
+			Expect(manifestPath).To(BeAnExistingFile())
+
+			data, err := os.ReadFile(manifestPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			var manifest backupManifest
+			Expect(json.Unmarshal(data, &manifest)).To(Succeed())
+
+			Expect(manifest.APIVersion).To(Equal("k2s.backup/v1"))
+			Expect(manifest.Kind).To(Equal("SystemBackup"))
+			Expect(manifest.Metadata.BackupTool).To(Equal("k2s system backup"))
+			Expect(manifest.Metadata.BackupFormatVersion).To(Equal("1"))
+			Expect(manifest.Cluster.Name).To(Equal("test-cluster"))
+			Expect(manifest.Content.Included.ClusterResources).To(BeTrue())
+			Expect(manifest.Content.Included.Namespaces).To(Equal([]string{"default", "my-app"}))
+			Expect(manifest.Content.Excluded.Namespaces).To(Equal([]string{"kube-system"}))
+			Expect(manifest.ConfigSnapshot.Source).To(Equal("config/config.json"))
+		})
+	})
+
+	Describe("createZipFromDirectory", func() {
+		It("creates a valid zip archive containing relative paths", func() {
+			stagingDir := GinkgoT().TempDir()
+			zipDest := filepath.Join(GinkgoT().TempDir(), "backup.zip")
+
+			// Create test files and directories
+			Expect(os.WriteFile(filepath.Join(stagingDir, "backup.json"), []byte("{}"), 0644)).To(Succeed())
+			cfgSubDir := filepath.Join(stagingDir, "config")
+			Expect(os.MkdirAll(cfgSubDir, 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(cfgSubDir, "config.json"), []byte("{}"), 0644)).To(Succeed())
+			nsSubDir := filepath.Join(stagingDir, "Namespaced", "default")
+			Expect(os.MkdirAll(nsSubDir, 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(nsSubDir, "pods.yaml"), []byte("apiVersion: v1"), 0644)).To(Succeed())
+
+			err := createZipFromDirectory(stagingDir, zipDest)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(zipDest).To(BeAnExistingFile())
+
+			zr, err := zip.OpenReader(zipDest)
+			Expect(err).NotTo(HaveOccurred())
+			defer zr.Close()
+
+			var fileNames []string
+			for _, f := range zr.File {
+				fileNames = append(fileNames, f.Name)
+			}
+
+			Expect(fileNames).To(ContainElement("backup.json"))
+			Expect(fileNames).To(ContainElement("config/config.json"))
+			Expect(fileNames).To(ContainElement("Namespaced/default/pods.yaml"))
+		})
+	})
+
+	Describe("tarGzDirectory and tarGzSingleFile", func() {
+		It("archives a directory to tar.gz", func() {
+			srcDir := GinkgoT().TempDir()
+			destTarGz := filepath.Join(GinkgoT().TempDir(), "archive.tar.gz")
+
+			Expect(os.WriteFile(filepath.Join(srcDir, "test.txt"), []byte("hello world"), 0644)).To(Succeed())
+
+			err := tarGzDirectory(srcDir, destTarGz)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(destTarGz).To(BeAnExistingFile())
+		})
+
+		It("archives a single file to tar.gz", func() {
+			srcFile := filepath.Join(GinkgoT().TempDir(), "single.txt")
+			destTarGz := filepath.Join(GinkgoT().TempDir(), "single.tar.gz")
+
+			Expect(os.WriteFile(srcFile, []byte("single file content"), 0644)).To(Succeed())
+
+			err := tarGzSingleFile(srcFile, destTarGz)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(destTarGz).To(BeAnExistingFile())
+		})
+	})
+
+	Describe("executeBackupHooks", func() {
+		It("skips hooks for disabled addons without error", func() {
+			installDir := GinkgoT().TempDir()
+			stagingDir := GinkgoT().TempDir()
+
+			addonHookDir := filepath.Join(installDir, "addons", "disabled-addon")
+			Expect(os.MkdirAll(addonHookDir, 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(addonHookDir, "Backup.sh"), []byte("#!/bin/sh\nexit 0\n"), 0755)).To(Succeed())
+
+			Expect(func() {
+				executeBackupHooks(installDir, stagingDir, "")
+			}).NotTo(Panic())
+		})
+	})
+})

--- a/internal/provider/system_linux.go
+++ b/internal/provider/system_linux.go
@@ -61,9 +61,8 @@ func (p *linuxSystemProvider) Compact(_ SystemCompactConfig) error {
 		"VHDX compaction is a Windows/Hyper-V operation; use 'qemu-img convert' to compact QCOW2 images")
 }
 
-func (p *linuxSystemProvider) Backup(_ SystemBackupConfig) error {
-	return NotSupportedError("system backup",
-		"cluster backup on Linux hosts is not yet implemented")
+func (p *linuxSystemProvider) Backup(cfg SystemBackupConfig) error {
+	return runLinuxSystemBackup(p.installDir, cfg)
 }
 
 func (p *linuxSystemProvider) Restore(_ SystemRestoreConfig) error {

--- a/internal/provider/system_windows.go
+++ b/internal/provider/system_windows.go
@@ -149,10 +149,10 @@ func (p *windowsSystemProvider) Backup(cfg SystemBackupConfig) error {
 	psCmd := p.scriptPath("backup/Start-SystemBackup.ps1")
 	var params string
 	if cfg.BackupFile != "" {
-		params += fmt.Sprintf(" -BackupFile '%s'", cfg.BackupFile)
+		params += " -BackupFile " + utils.EscapeWithSingleQuotes(cfg.BackupFile)
 	}
 	if cfg.AdditionalHooksDir != "" {
-		params += fmt.Sprintf(" -AdditionalHooksDir '%s'", cfg.AdditionalHooksDir)
+		params += " -AdditionalHooksDir " + utils.EscapeWithSingleQuotes(cfg.AdditionalHooksDir)
 	}
 	if cfg.SkipImages {
 		params += " -SkipImages"

--- a/test/e2e/cluster/backup/system_backup_test.go
+++ b/test/e2e/cluster/backup/system_backup_test.go
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText:  © 2026 Siemens Healthineers AG
+// SPDX-License-Identifier:   MIT
+
+package systembackup
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/siemens-healthineers/k2s/test/framework"
+)
+
+type backupManifest struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		BackupTimestamp     string `json:"backupTimestamp"`
+		BackupTool          string `json:"backupTool"`
+		BackupToolVersion   string `json:"backupToolVersion"`
+		BackupFormatVersion string `json:"backupFormatVersion"`
+	} `json:"metadata"`
+	Cluster struct {
+		Name       string `json:"name"`
+		K2sVersion string `json:"k2sVersion"`
+	} `json:"cluster"`
+	Content struct {
+		Included struct {
+			ClusterResources bool     `json:"clusterResources"`
+			Namespaces       []string `json:"namespaces"`
+		} `json:"included"`
+		Excluded struct {
+			Namespaces          []string `json:"namespaces"`
+			NamespacedResources []string `json:"namespacedResources"`
+			ClusterResources    []string `json:"clusterResources"`
+		} `json:"excluded"`
+	} `json:"content"`
+	ConfigSnapshot struct {
+		Source string `json:"source"`
+	} `json:"configSnapshot"`
+}
+
+var (
+	suite         *framework.K2sTestSuite
+	testBackupDir string
+)
+
+func TestSystemBackup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster System Backup Acceptance Tests", Label("core", "acceptance", "internet-required", "setup-required", "system-running", "system-backup"))
+}
+
+var _ = BeforeSuite(func(ctx context.Context) {
+	suite = framework.Setup(ctx, framework.SystemMustBeRunning,
+		framework.ClusterTestStepPollInterval(200*time.Millisecond),
+		framework.ClusterTestStepTimeout(15*time.Minute),
+	)
+
+	var err error
+	testBackupDir, err = os.MkdirTemp("", "k2s-system-backup-test-*")
+	Expect(err).NotTo(HaveOccurred(), "failed to create temporary backup directory")
+})
+
+var _ = AfterSuite(func(ctx context.Context) {
+	if testBackupDir != "" {
+		_ = os.RemoveAll(testBackupDir)
+	}
+	suite.TearDown(ctx)
+})
+
+var _ = Describe("system backup", func() {
+	const entryMissingPattern = "%s not found in backup zip archive"
+
+	hasZipEntry := func(files []*zip.File, target string) bool {
+		normalizedTarget := strings.ReplaceAll(target, "\\", "/")
+		for _, f := range files {
+			normalizedName := strings.ReplaceAll(f.Name, "\\", "/")
+			if normalizedName == normalizedTarget || strings.HasSuffix(normalizedName, normalizedTarget) {
+				return true
+			}
+		}
+		return false
+	}
+
+	readManifest := func(r *zip.ReadCloser) *backupManifest {
+		for _, f := range r.File {
+			normalizedName := strings.ReplaceAll(f.Name, "\\", "/")
+			if normalizedName == "backup.json" {
+				rc, err := f.Open()
+				Expect(err).NotTo(HaveOccurred(), "failed to open backup.json from zip")
+				defer rc.Close()
+
+				data, err := io.ReadAll(rc)
+				Expect(err).NotTo(HaveOccurred(), "failed to read backup.json content")
+
+				var manifest backupManifest
+				err = json.Unmarshal(data, &manifest)
+				Expect(err).NotTo(HaveOccurred(), "failed to unmarshal backup.json")
+				return &manifest
+			}
+		}
+		Fail("backup.json not found in zip archive")
+		return nil
+	}
+
+	It("creates a system backup with specified file path and validates archive structure and manifest", func(ctx context.Context) {
+		backupFilePath := filepath.Join(testBackupDir, fmt.Sprintf("system-backup-%d.zip", time.Now().UnixNano()))
+		DeferCleanup(func() {
+			_ = os.Remove(backupFilePath)
+		})
+
+		output := suite.K2sCli().MustExec(ctx, "system", "backup", "-f", backupFilePath, "--output")
+		Expect(output).NotTo(BeEmpty(), "system backup output should not be empty")
+
+		fileInfo, err := os.Stat(backupFilePath)
+		Expect(err).NotTo(HaveOccurred(), "backup zip file should exist on disk")
+		Expect(fileInfo.Size()).To(BeNumerically(">", 0), "backup zip file size should be greater than 0")
+
+		r, err := zip.OpenReader(backupFilePath)
+		Expect(err).NotTo(HaveOccurred(), "failed to open backup zip file as a valid zip archive")
+		defer r.Close()
+
+		Expect(hasZipEntry(r.File, "backup.json")).To(BeTrue(), entryMissingPattern, "backup.json")
+		Expect(hasZipEntry(r.File, "config/config.json")).To(BeTrue(), entryMissingPattern, "config/config.json")
+
+		manifest := readManifest(r)
+		Expect(manifest).NotTo(BeNil())
+		Expect(manifest.APIVersion).To(Equal("k2s.backup/v1"), "manifest apiVersion mismatch")
+		Expect(manifest.Kind).To(Equal("SystemBackup"), "manifest kind mismatch")
+		Expect(manifest.Metadata.BackupTimestamp).NotTo(BeEmpty(), "metadata.backupTimestamp should not be empty")
+		Expect(manifest.Metadata.BackupTool).To(ContainSubstring("backup"), "metadata.backupTool should contain 'backup'")
+		Expect(manifest.Metadata.BackupToolVersion).NotTo(BeEmpty(), "metadata.backupToolVersion should not be empty")
+		Expect(manifest.Metadata.BackupFormatVersion).NotTo(BeEmpty(), "metadata.backupFormatVersion should not be empty")
+		Expect(manifest.Cluster.Name).NotTo(BeEmpty(), "cluster.name should not be empty")
+		Expect(manifest.ConfigSnapshot.Source).To(Equal("config/config.json"), "configSnapshot.source mismatch")
+	})
+
+	It("creates a system backup with --skip-images and --skip-pvs flags", func(ctx context.Context) {
+		backupFilePath := filepath.Join(testBackupDir, fmt.Sprintf("system-backup-skip-%d.zip", time.Now().UnixNano()))
+		DeferCleanup(func() {
+			_ = os.Remove(backupFilePath)
+		})
+
+		output := suite.K2sCli().MustExec(ctx, "system", "backup", "-f", backupFilePath, "--skip-images", "--skip-pvs", "--output")
+		Expect(output).NotTo(BeEmpty(), "system backup output should not be empty")
+
+		fileInfo, err := os.Stat(backupFilePath)
+		Expect(err).NotTo(HaveOccurred(), "backup zip file should exist on disk")
+		Expect(fileInfo.Size()).To(BeNumerically(">", 0), "backup zip file size should be greater than 0")
+
+		r, err := zip.OpenReader(backupFilePath)
+		Expect(err).NotTo(HaveOccurred(), "failed to open backup zip file as a valid zip archive")
+		defer r.Close()
+
+		Expect(hasZipEntry(r.File, "backup.json")).To(BeTrue(), entryMissingPattern, "backup.json")
+		Expect(hasZipEntry(r.File, "config/config.json")).To(BeTrue(), entryMissingPattern, "config/config.json")
+
+		manifest := readManifest(r)
+		Expect(manifest).NotTo(BeNil())
+		Expect(manifest.APIVersion).To(Equal("k2s.backup/v1"), "manifest apiVersion mismatch")
+		Expect(manifest.Kind).To(Equal("SystemBackup"), "manifest kind mismatch")
+		Expect(manifest.Metadata.BackupTimestamp).NotTo(BeEmpty(), "metadata.backupTimestamp should not be empty")
+		Expect(manifest.Metadata.BackupTool).To(ContainSubstring("backup"), "metadata.backupTool should contain 'backup'")
+		Expect(manifest.Metadata.BackupToolVersion).NotTo(BeEmpty(), "metadata.backupToolVersion should not be empty")
+		Expect(manifest.Metadata.BackupFormatVersion).NotTo(BeEmpty(), "metadata.backupFormatVersion should not be empty")
+	})
+})


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2026 Siemens Healthineers AG

SPDX-License-Identifier: MIT
-->
<!-- markdownlint-disable MD041 -->

Fixes #2221

### Motivation

Enable `k2s system backup` on Linux hosts while preserving the existing Windows implementation.

### Modifications

- Added native Linux system backup support.
- Back up cluster resources, persistent volumes, and container images.
- Added Linux Bash backup hook support for addons and custom hook directories.
- Added Linux provider implementations and unit tests.
- Added an end-to-end system backup test.
- Updated CLI and operational documentation for Linux usage, options, output formats, and hooks.
- Made the backup output path optional, defaulting to a temporary directory.

### Verification

- Added unit tests covering backup configuration, resource cleanup, manifest generation, ZIP creation, PV archives, and backup hooks.
- Added an end-to-end backup test.
- Manual usecase testing on debian 13

<!--
### Beyond this PR

Thank you for submitting this!

K2s is seeking more community involvement to help to keep it viable.

-->